### PR TITLE
Allow decimal powers and improve rounding algorithm.

### DIFF
--- a/include/exceptions.hpp
+++ b/include/exceptions.hpp
@@ -31,6 +31,8 @@
 #pragma once
 
 #include <exception>
+#include <string>
+#include <utility>
 
 namespace steppable::exceptions
 {
@@ -38,19 +40,22 @@ namespace steppable::exceptions
      * @class ZeroDenominatorException
      * @brief Thrown when initializing a fraction with zero as denominator.
      */
-    class ZeroDenominatorException : public std::exception
+    class ZeroDenominatorException final : public std::exception
     {
     public:
-        const char* what() const throw() { return "The denominator is zero, which is not allowed."; }
+        [[nodiscard]] const char* what() const noexcept override
+        {
+            return "The denominator is zero, which is not allowed.";
+        }
     };
 
     /**
      * @class MultiLengthLetterException
      * @brief Thrown when initializing a Key object with two or more letters.
      */
-    class MultiLengthLetterException : public std::exception
+    class MultiLengthLetterException final : public std::exception
     {
     public:
-        const char* what() const throw() { return "The length of letter exceeds the 1 limit."; }
+        [[nodiscard]] const char* what() const noexcept override { return "The length of letter exceeds the 1 limit."; }
     };
 } // namespace steppable::exceptions

--- a/include/fn/basicArithm.hpp
+++ b/include/fn/basicArithm.hpp
@@ -186,9 +186,11 @@ namespace steppable::__internals::arithmetic
      * @param _number The number to take root of.
      * @param base The base of the root.
      * @param decimals The decimals of the operation.
+     * @param steps The steps to show while taking the root.
+     *
      * @return The result of the root operation.
      */
-    std::string root(const std::string& _number, const std::string& base, const size_t decimals = 8);
+    std::string root(const std::string& _number, const std::string& base, const size_t decimals = 8, const int steps = 2);
 
     /**
      * @brief Executes a given predicate function a specified number of times.

--- a/include/fraction.hpp
+++ b/include/fraction.hpp
@@ -58,6 +58,13 @@ namespace steppable
         Fraction(const std::string& top = "1", const std::string& bottom = "1");
 
         /**
+         * @brief Initialized a fraction from a number.
+         *
+         * @param number The number to convert to a fraction.
+         */
+        Fraction(const Number& number);
+
+        /**
          * @brief Initializes a fraction with no top component and bottom component specified.
          * By default, this fraction equals to 1.
          */

--- a/include/fraction.hpp
+++ b/include/fraction.hpp
@@ -34,7 +34,6 @@
 
 #include <array>
 #include <string>
-#include <string_view>
 
 namespace steppable
 {

--- a/include/fraction.hpp
+++ b/include/fraction.hpp
@@ -75,8 +75,11 @@ namespace steppable
         /**
          * @brief Returns the fraction as a string.
          * The string is formatted as "top/bottom", and it will automatically simplify the fraction.
+         *
+         * @param inLine Whether to present the fraction in a single line.
+         * @return The fraction as a string.
          */
-        std::string present();
+        std::string present(const bool inLine = true);
 
         /**
          * @brief Returns the fraction as an array of its top and bottom components.

--- a/include/fraction.hpp
+++ b/include/fraction.hpp
@@ -32,7 +32,9 @@
 
 #include "number.hpp"
 
+#include <array>
 #include <string>
+#include <string_view>
 
 namespace steppable
 {
@@ -75,6 +77,12 @@ namespace steppable
          * The string is formatted as "top/bottom", and it will automatically simplify the fraction.
          */
         std::string present();
+
+        /**
+         * @brief Returns the fraction as an array of its top and bottom components.
+         * @return The array of top and bottom components.
+         */
+        std::array<std::string, 2> asArray() const;
 
         /**
          * @brief Adds two fractions together.

--- a/include/rounding.hpp
+++ b/include/rounding.hpp
@@ -28,10 +28,11 @@ namespace steppable::__internals::numUtils
     /**
      * @brief Round off a number to the nearest integer.
      *
-     * @param[in] number The number to round.
+     * @param[in] _number The number to round.
+     * @param[in] digits The number of decimal places to round to.
      * @return The rounded number.
      */
-    std::string roundOff(const std::string& number);
+    std::string roundOff(const std::string& _number, const size_t digits = 0);
 
     /**
      * @brief Move the decimal places of a number.

--- a/include/symbols.hpp
+++ b/include/symbols.hpp
@@ -33,8 +33,132 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <string>
+#include <vector>
 
+#pragma once
+
+#include <string>
+#include <vector>
+
+/**
+ * @namespace steppable::prettyPrint
+ * @brief The namespace containing utilities for pretty printing.
+ */
+namespace steppable::prettyPrint
+{
+    /**
+     * @brief Represents a position in the console.
+     */
+    struct Position
+    {
+        long long x = 0;
+        long long y = 0;
+    };
+
+    // // Not currently in use.
+    // enum PrintingAlignment
+    // {
+    //     BASELINE = 0,
+    //     MIDDLE = 1
+    // };
+
+    // struct PrintingObj
+    // {
+    //     std::string str;
+    //     PrintingAlignment alignment;
+    // };
+
+    /**
+     * @brief Represents a console output buffer.
+     */
+    class ConsoleOutput
+    {
+    private:
+        /// @brief The current position.
+        Position curPos;
+
+        /// @brief The buffer object.
+        std::vector<std::vector<char>> buffer;
+
+        /// @brief The height of the buffer.
+        long long height = 10;
+
+        /// @brief The width of the buffer.
+        long long width = 10;
+
+    public:
+        /**
+         * @brief Creates a new console output buffer.
+         *
+         * @param height The height of the buffer.
+         * @param width The width of the buffer.
+         */
+        ConsoleOutput(long long height, long long width);
+
+        /**
+         * @brief Writes a character to the buffer.
+         *
+         * @param c The character to write.
+         * @param dLine The change in line.
+         * @param dCol The change in column.
+         * @param updatePos Whether to update the current position.
+         */
+        void write(const char c, const long long dLine, const long long dCol, bool updatePos = false);
+
+        /**
+         * @brief Writes a character to the buffer.
+         *
+         * @param c The character to write.
+         * @param pos The position to write to.
+         * @param updatePos Whether to update the current position.
+         */
+        void write(const char c, const Position& pos, bool updatePos = false);
+
+        /**
+         * @brief Writes a string to the buffer.
+         *
+         * @param s The string to write.
+         * @param dLine The change in line.
+         * @param dCol The change in column.
+         * @param updatePos Whether to update the current position.
+         */
+        void write(const std::string& s, const Position& pos, bool updatePos = false);
+
+        /**
+         * @brief Gets the buffer as a string.
+         * @return The buffer as a string.
+         */
+        [[nodiscard]] std::string asString() const;
+    };
+
+    /**
+     * @brief Gets the minimal width needed to print a string.
+     *
+     * @param s The string.
+     * @return The width of the string.
+     */
+    size_t getStringWidth(const std::string& s);
+
+    /**
+     * @brief Gets the minimal height needed to print a string.
+     *
+     * @param s The string.
+     * @return The height of the string.
+     */
+    size_t getStringHeight(const std::string& s);
+} // namespace steppable::prettyPrint
+
+/**
+ * @namespace steppable::__internals::symbols
+ * @brief The namespace containing various unicode symbols.
+ *
+ * @deprecated This namespace is deprecated and will be removed in the future, as the unicode output is not flexible
+ * enough.
+ * @warning Usage of this namespace is strongly discouraged. Use the steppable::prettyPrint namespace for basic tools,
+ * and implement yours in steppable::prettyPrint::printers.
+ */
 namespace steppable::__internals::symbols
 {
 /// @brief The because symbol (3 dots in a triangle, Unicode U+2235)
@@ -72,7 +196,7 @@ namespace steppable::__internals::symbols
 #define SUB_MAGIC_NUMBER 8272
 
     /// @brief A list of subscript characters.
-    extern const std::array<std::string_view, 10>& SUPERSCRIPTS;
+    extern const std::array<std::string, 10>& SUPERSCRIPTS;
 
     /**
      * @brief Create a subscript string from a normal string.
@@ -121,7 +245,7 @@ namespace steppable::__internals::symbols
      * @param[in] normal The normal character.
      * @return The superscript string.
      */
-    std::string_view makeSuperscript(char normal);
+    std::string makeSuperscript(char normal);
 
     /**
      * @brief Makes a surd expression from a radicand.
@@ -131,3 +255,47 @@ namespace steppable::__internals::symbols
      */
     std::string makeSurd(const std::string& radicand);
 } // namespace steppable::__internals::symbols
+
+/**
+ * @namespace steppable::prettyPrint::printers
+ * @brief The custom-implemented printer engines for outputting expressions.
+ */
+namespace steppable::prettyPrint::printers
+{
+    /**
+     * @brief Pretty print a root expression.
+     *
+     * @param radicand The radicand.
+     * @param index The index.
+     * @return The pretty printed root expression.
+     */
+    std::string ppRoot(const std::string& radicand, const std::string& index = "2");
+
+    /**
+     * @brief Pretty print a fraction.
+     *
+     * @param numerator The numerator.
+     * @param denominator The denominator.
+     * @param inLine Whether to print in a single line.
+     * @return The pretty printed fraction.
+     */
+    std::string ppFraction(const std::string& numerator, const std::string& denominator, const bool inLine = false);
+
+    /**
+     * @brief Pretty print a base expression, (aka, subscript).
+     *
+     * @param base The base.
+     * @param subscript The subscript.
+     * @return The pretty printed base expression.
+     */
+    std::string ppSubscript(const std::string& base, const std::string& subscript);
+
+    /**
+     * @brief Pretty print a power expression, (aka, superscript).
+     *
+     * @param base The base.
+     * @param exponent The exponent.
+     * @return The pretty printed power expression.
+     */
+    std::string ppSuperscript(const std::string& base, const std::string& superscript);
+} // namespace steppable::prettyPrint::printers

--- a/include/symbols.hpp
+++ b/include/symbols.hpp
@@ -47,8 +47,12 @@ namespace steppable::__internals::symbols
 /// @brief The divide symbol (Unicode U+00F7)
 #define DIVIDED_BY "\u00F7"
 
+#define SURD "\u221A"
+#define COMBINE_MACRON "\u0305"
+
 /// @brief The large dot symbol (Unicode U+25C9)
 #define LARGE_DOT "\u25C9"
+#define ABOVE_DOT "\u02D9"
 
 // Subscripts
 /**
@@ -118,4 +122,12 @@ namespace steppable::__internals::symbols
      * @return The superscript string.
      */
     std::string_view makeSuperscript(char normal);
+
+    /**
+     * @brief Makes a surd expression from a radicand.
+     *
+     * @param radicand The radicand.
+     * @return The surd expression.
+     */
+    std::string makeSurd(const std::string& radicand);
 } // namespace steppable::__internals::symbols

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -40,6 +40,9 @@
 #include <array>
 #include <chrono>
 #include <iomanip>
+#include <iostream>
+#include <locale.h>
+#include <locale>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -72,6 +75,20 @@
 
 namespace steppable::__internals::utils
 {
+#ifndef MS_STDLIB_BUGS
+    #if (_MSC_VER || __MINGW32__ || __MSVCRT__)
+        #define MS_STDLIB_BUGS 1
+    #else
+        #define MS_STDLIB_BUGS 0
+    #endif
+#endif
+
+#if MS_STDLIB_BUGS
+    #include <fcntl.h>
+    #include <io.h>
+#endif
+
+    void initLocale();
 #ifdef WINDOWS
     #include <fcntl.h>
     #include <windows.h>
@@ -134,6 +151,7 @@ namespace steppable::__internals::utils
          */
         Utf8CodePage() : oldCodePage(GetConsoleOutputCP())
         {
+            initLocale();
             SetConsoleOutputCP(CP_UTF8);
             dwModeOrig = enableVtMode();
         }
@@ -164,6 +182,8 @@ namespace steppable::__internals::utils
      */
     class Utf8CodePage
     {
+    public:
+        Utf8CodePage() { initLocale(); }
     };
 #endif
 } // namespace steppable::__internals::utils

--- a/src/baseConvert/baseConvert.cpp
+++ b/src/baseConvert/baseConvert.cpp
@@ -33,6 +33,7 @@
 #include "baseConvertReport.hpp"
 #include "fn/basicArithm.hpp"
 #include "output.hpp"
+#include "symbols.hpp"
 #include "util.hpp"
 
 #include <sstream>
@@ -45,6 +46,22 @@ using namespace steppable::__internals::stringUtils;
 using namespace steppable::__internals::arithmetic;
 using namespace steppable::__internals::symbols;
 using namespace steppable::output;
+
+namespace steppable::prettyPrint::printers
+{
+    std::string ppSubscript(const std::string& base, const std::string& subscript)
+    {
+        auto subscriptWidth = prettyPrint::getStringWidth(subscript);
+        auto width = prettyPrint::getStringWidth(base) + subscriptWidth + 1,
+             height = prettyPrint::getStringHeight(base) + 1; // +1 for the superscript
+
+        prettyPrint::ConsoleOutput output(height, width);
+        prettyPrint::Position pos{ static_cast<long long>(width - subscriptWidth - 1), 1 };
+        output.write(subscript, pos, false);
+        output.write(base, { 0, 0 }, false);
+        return output.asString();
+    }
+} // namespace steppable::prettyPrint::printers
 
 namespace steppable::__internals::arithmetic
 {
@@ -112,6 +129,7 @@ namespace steppable::__internals::arithmetic
 #ifndef NO_MAIN
 int main(const int _argc, const char* _argv[])
 {
+    std::cout << steppable::prettyPrint::printers::ppSubscript("342", "32341");
     Utf8CodePage _;
     ProgramArgs program(_argc, _argv);
     program.addPosArg('a', "Number to convert");

--- a/src/division/division.cpp
+++ b/src/division/division.cpp
@@ -219,7 +219,7 @@ namespace steppable::__internals::arithmetic
         auto numberDecimals = quotient.length() - numberIntegers;
         quotient = removeLeadingZeros(quotient);
         std::string finalQuotient = quotient;
-        if ((numberIntegers < 0) and (-numberIntegers + 1 >= decimals))
+        if ((numberIntegers < 0) and (-numberIntegers >= decimals))
         {
             if (steps != 0)
                 warning("The result is inaccurate, as the decimals you specified is not enough to display the result.");
@@ -228,26 +228,12 @@ namespace steppable::__internals::arithmetic
 
         // Scenario 1: No decimal places returned
         // Solution  : Do nothing
-        if (static_cast<size_t>(numberIntegers) == quotient.length() - 1 or decimals == 0)
+        if (static_cast<size_t>(numberIntegers) == quotient.length() - 1)
             finalQuotient = quotient.substr(0, quotient.length() - 1);
         // Scenario 2: Decimal places more than requested
         // Solution  : Round to the nearest decimal place
         else if (numberDecimals >= decimals and numberIntegers > 0)
         {
-            bool carry = false;
-            if (not quotient.empty() and quotient.back() > '4')
-            {
-                quotient = add(quotient, "10", 0, false, false);
-
-                if (quotient.front() == '0')
-                    quotient.erase(0, 1);
-                else
-                {
-                    carry = true;
-                    quotient += '0';
-                }
-            }
-            quotient.pop_back();
             auto beforeDecimal = quotient.substr(0, numberIntegers),
                  afterDecimal = quotient.substr(numberIntegers, numberDecimals);
             if (beforeDecimal.empty())
@@ -256,9 +242,7 @@ namespace steppable::__internals::arithmetic
                 finalQuotient = beforeDecimal + "." + afterDecimal;
             else
                 finalQuotient = beforeDecimal;
-
-            if (afterDecimal.length() > decimals)
-                finalQuotient = multiply(finalQuotient, "10", 0);
+            finalQuotient = roundOff(finalQuotient, _decimals);
         }
         // Scenario 3: Result is less than one
         // Solution  : 1. Append "0." to the beginning
@@ -266,20 +250,8 @@ namespace steppable::__internals::arithmetic
         //             3. Apply rounding
         else if (numberIntegers <= 0)
         {
-            if (not quotient.empty() and quotient.back() > '4')
-            {
-                quotient = add(quotient, "10", 0, false, false);
-                if (quotient.front() == '0')
-                    quotient.erase(0, 1);
-                else
-                    quotient += '0';
-            }
-            quotient.pop_back();
             auto afterDecimal = std::string(-numberIntegers, '0') + quotient;
-            finalQuotient = "0." + afterDecimal;
-
-            if (afterDecimal.length() > decimals)
-                finalQuotient = multiply(finalQuotient, "10", 0);
+            finalQuotient = roundOff("0." + afterDecimal, _decimals);
         }
 
         // Scenario 4: Decimal places less than requested

--- a/src/division/division.cpp
+++ b/src/division/division.cpp
@@ -33,6 +33,7 @@
 #include "fn/basicArithm.hpp"
 #include "logging.hpp"
 #include "output.hpp"
+#include "rounding.hpp"
 #include "util.hpp"
 
 #include <cstddef>
@@ -145,6 +146,9 @@ namespace steppable::__internals::arithmetic
                 ss << "1";
             return ss.str();
         }
+
+        if (compare(_divisor, "1", 0) == "2")
+            return roundOff(static_cast<std::string>(_number), _decimals);
 
         auto splitNumberResult = splitNumber(_number, _divisor, false, true);
         bool numberIsNegative = splitNumberResult.aIsNegative, divisorIsNegative = splitNumberResult.bIsNegative;

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -38,6 +38,11 @@
 
 #include <string>
 
+#ifdef WINDOWS
+    #undef max
+    #undef min
+#endif
+
 using namespace steppable::__internals::arithmetic;
 using namespace steppable::__internals::numUtils;
 

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -33,12 +33,29 @@
 #include "exceptions.hpp"
 #include "fn/basicArithm.hpp"
 #include "number.hpp"
+#include "symbols.hpp"
 #include "util.hpp"
 
 #include <string>
 
 using namespace steppable::__internals::arithmetic;
 using namespace steppable::__internals::numUtils;
+
+namespace steppable::prettyPrint::printers
+{
+    std::string ppFraction(const std::string& top, const std::string& bottom, const bool inLine)
+    {
+        // Output in single line
+        if (inLine)
+            return top + "/" + bottom;
+        // Output in three lines, with top and bottom aligned to center.
+        auto topWidth = prettyPrint::getStringWidth(top), bottomWidth = prettyPrint::getStringWidth(bottom);
+        auto width = std::max(topWidth, bottomWidth) + 2;
+        auto topSpacing = std::string((width - topWidth) / 2, ' '),
+             bottomSpacing = std::string((width - bottomWidth) / 2, ' ');
+        return topSpacing + top + '\n' + std::string(width, '-') + '\n' + bottomSpacing + bottom;
+    }
+} // namespace steppable::prettyPrint::printers
 
 namespace steppable
 {
@@ -64,10 +81,10 @@ namespace steppable
         simplify();
     }
 
-    std::string Fraction::present()
+    std::string Fraction::present(const bool inLine)
     {
         simplify();
-        return top + "/" + bottom;
+        return prettyPrint::printers::ppFraction(top, bottom, inLine);
     }
 
     std::array<std::string, 2> Fraction::asArray() const { return { top, bottom }; }

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -56,6 +56,13 @@ namespace steppable
         this->bottom = bottom;
     }
 
+    Fraction::Fraction(const Number& number)
+    {
+        this->top = number.present();
+        this->bottom = "1";
+        simplify();
+    }
+
     std::string Fraction::present()
     {
         simplify();
@@ -203,6 +210,12 @@ namespace steppable
 
     void Fraction::simplify()
     {
+        // Make sure the fraction does not contain decimal points.
+        while (isDecimal(top) or isDecimal(bottom))
+        {
+            top = multiply(top, "10", 0);
+            bottom = multiply(bottom, "10", 0);
+        }
         auto gcd = getGCD(top, bottom);
         top = divide(top, gcd, 0, 0);
         bottom = divide(bottom, gcd, 0, 0);

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -54,6 +54,7 @@ namespace steppable
             throw exceptions::ZeroDenominatorException();
         this->top = top;
         this->bottom = bottom;
+        simplify();
     }
 
     Fraction::Fraction(const Number& number)
@@ -68,6 +69,8 @@ namespace steppable
         simplify();
         return top + "/" + bottom;
     }
+
+    std::array<std::string, 2> Fraction::asArray() const { return { top, bottom }; }
 
     Fraction Fraction::operator+(const Fraction& rhs) const
     {

--- a/src/number.cpp
+++ b/src/number.cpp
@@ -33,6 +33,11 @@
 #include "fn/basicArithm.hpp"
 #include "output.hpp"
 
+#ifdef WINDOWS
+    #undef max
+    #undef min
+#endif
+
 namespace steppable
 {
     using namespace steppable::__internals::arithmetic;

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -29,6 +29,7 @@
  */
 #include "argParse.hpp"
 #include "fn/basicArithm.hpp"
+#include "fraction.hpp"
 #include "powerReport.hpp"
 #include "util.hpp"
 
@@ -41,6 +42,19 @@ namespace steppable::__internals::arithmetic
     std::string power(const std::string_view _number, const std::string_view& _raiseTo, const int steps)
     {
         std::string raiseTo = static_cast<std::string>(_raiseTo), number = static_cast<std::string>(_number);
+
+        if (isDecimal(raiseTo))
+        {
+            // Raising to decimal power.
+            // Steps:
+            // 1. Convert the decimal to a fraction.
+            // 2. Raise the number to the numerator of the fraction.
+            // 3. Take the root of the number to the denominator of the fraction.
+            const auto& fraction = Fraction(raiseTo);
+            const auto& [top, bottom] = fraction.asArray();
+            const auto &powerResult = power(_number, top, 0), rootResult = root(powerResult, bottom);
+            return reportPowerRoot(number, raiseTo, fraction, rootResult, steps);
+        }
 
         // Here, we attempt to give a quick answer, instead of doing pointless iterations.
         if (number == "1")

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -31,11 +31,27 @@
 #include "fn/basicArithm.hpp"
 #include "fraction.hpp"
 #include "powerReport.hpp"
+#include "symbols.hpp"
 #include "util.hpp"
 
 using namespace steppable::__internals::numUtils;
 using namespace steppable::output;
 using namespace steppable::__internals::arithmetic;
+
+namespace steppable::prettyPrint::printers
+{
+    std::string ppSuperscript(const std::string& base, const std::string& superscript)
+    {
+        auto width = prettyPrint::getStringWidth(base) + 1,
+             height = prettyPrint::getStringHeight(base) + 1; // +1 for the superscript
+
+        prettyPrint::ConsoleOutput output(height, width);
+        prettyPrint::Position pos{ static_cast<long long>(width - 1), 0 };
+        output.write(superscript, pos, false);
+        output.write(base, { 0, 1 }, false);
+        return output.asString();
+    }
+} // namespace steppable::prettyPrint::printers
 
 namespace steppable::__internals::arithmetic
 {

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -52,7 +52,7 @@ namespace steppable::__internals::arithmetic
             // 3. Take the root of the number to the denominator of the fraction.
             const auto& fraction = Fraction(raiseTo);
             const auto& [top, bottom] = fraction.asArray();
-            const auto &powerResult = power(_number, top, 0), rootResult = root(powerResult, bottom);
+            const auto &powerResult = power(_number, top, 0), rootResult = root(powerResult, bottom, 8, 0);
             return reportPowerRoot(number, raiseTo, fraction, rootResult, steps);
         }
 

--- a/src/power/powerReport.cpp
+++ b/src/power/powerReport.cpp
@@ -32,6 +32,7 @@
 #include "powerReport.hpp"
 
 #include "fn/basicArithm.hpp"
+#include "fraction.hpp"
 #include "symbols.hpp"
 
 #include <sstream>
@@ -40,6 +41,26 @@ using namespace std::literals;
 using namespace steppable::output;
 using namespace steppable::__internals::symbols;
 using namespace steppable::__internals::arithmetic;
+
+std::string reportPowerRoot(const std::string& _number,
+                            const std::string& raiseTo,
+                            const steppable::Fraction& fraction,
+                            const std::string& result,
+                            const int steps)
+{
+    auto array = fraction.asArray();
+    std::stringstream ss;
+
+    if (steps == 2)
+        ss << "The exponent " << raiseTo << " is a decimal. Therefore, the result is a root." << '\n';
+    if (steps >= 1)
+    {
+        ss << _number << makeSuperscript(static_cast<std::string>(raiseTo));
+        ss << " = " << makeSuperscript(array[1]) << makeSurd(_number + makeSuperscript(array[0])) << " = ";
+    }
+    ss << result;
+    return ss.str();
+}
 
 std::string reportPower(const std::string_view _number,
                         const std::string_view& raiseTo,

--- a/src/power/powerReport.cpp
+++ b/src/power/powerReport.cpp
@@ -39,6 +39,7 @@
 
 using namespace std::literals;
 using namespace steppable::output;
+using namespace steppable::prettyPrint;
 using namespace steppable::__internals::symbols;
 using namespace steppable::__internals::arithmetic;
 
@@ -81,7 +82,7 @@ std::string reportPower(const std::string_view _number,
         if (steps == 2)
             return "Since the number is 0, the result is 0.";
         if (steps == 1)
-            return "0"s + makeSuperscript(static_cast<std::string>(raiseTo)) + " = 0";
+            return printers::ppSuperscript("0", static_cast<std::string>(raiseTo)) + " = 0";
         return "0";
     }
 
@@ -90,17 +91,17 @@ std::string reportPower(const std::string_view _number,
             number = multiply(number, numberOrig, 0);
         else
             number = divide("1", number, 0);
-        const auto& currentPower = add(i, "1", 0);
+        auto currentPower = add(i, "1", 0);
         if (steps == 2)
         {
             if (not negative)
                 ss << BECAUSE " " << multiply(number, numberOrig, 1) << '\n';
             else
                 ss << BECAUSE " " << divide("1", number, 1) << '\n';
-            ss << THEREFORE " " << numberOrig;
             if (negative)
-                ss << makeSuperscript('-');
-            ss << makeSuperscript(currentPower) << " = " << number << '\n';
+                currentPower = "-" + currentPower;
+
+            ss << printers::ppSuperscript(numberOrig, currentPower) << " = " << number << '\n';
         }
     });
 

--- a/src/power/powerReport.cpp
+++ b/src/power/powerReport.cpp
@@ -34,6 +34,7 @@
 #include "fn/basicArithm.hpp"
 #include "fraction.hpp"
 #include "symbols.hpp"
+#include "util.hpp"
 
 #include <sstream>
 
@@ -106,6 +107,8 @@ std::string reportPower(const std::string_view _number,
     });
 
 finish:
+    number = numUtils::standardizeNumber(number);
+
     if (negative)
     {
         if (steps == 2)

--- a/src/power/powerReport.hpp
+++ b/src/power/powerReport.hpp
@@ -27,7 +27,26 @@
  */
 #pragma once
 
+#include "fraction.hpp"
+
 #include <string>
+
+/**
+ * @brief Reports a power operation for a root.
+ *
+ * @param _number The number to raise.
+ * @param raiseTo The exponent to raise to.
+ * @param fraction The exponent as a fraction.
+ * @param result The root result.
+ * @param steps The steps to show.
+ *
+ * @return The forrmatted power report.
+ */
+std::string reportPowerRoot(const std::string& _number,
+                            const std::string& raiseTo,
+                            const steppable::Fraction& fraction,
+                            const std::string& result,
+                            const int steps);
 
 /**
  * @brief Reports a power operation.

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -114,7 +114,7 @@ namespace steppable::__internals::arithmetic
             auto test = power(radicand, base, 0);
 
             if (compare(newAvg, "0", 0) == "2")
-                return divide(radicand, denominator, 0, _decimals);
+                return numUtils::standardizeNumber(divide(radicand, denominator, 0, _decimals));
             if (compare(test, number, 0) == "1")
                 x = radicand;
             else if (compare(test, number, 0) == "0")

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -42,6 +42,8 @@ namespace steppable::__internals::arithmetic
 {
     std::string root(const std::string& _number, const std::string& base, const size_t _decimals)
     {
+
+
         auto decimals = _decimals + 1;
         size_t raisedTimes = 0;
         std::string number = static_cast<std::string>(_number);

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -80,9 +80,9 @@ namespace steppable::__internals::arithmetic
     {
         if (numUtils::isDecimal(base))
         {
-            const auto& fraction = Fraction(_number);
+            const auto& fraction = Fraction(base);
             const auto& [top, bottom] = fraction.asArray();
-            const auto &powerResult = power(_number, top, 0), rootResult = root(powerResult, bottom, _decimals, 0);
+            const auto &powerResult = power(_number, bottom, 0), rootResult = root(powerResult, top, _decimals, 0);
             return reportRootPower(_number, base, fraction, rootResult, steps);
         }
 

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -30,6 +30,8 @@
 
 #include "argParse.hpp"
 #include "fn/basicArithm.hpp"
+#include "fraction.hpp"
+#include "rootReport.hpp"
 #include "util.hpp"
 
 #include <string>
@@ -40,9 +42,15 @@ using namespace std::literals;
 
 namespace steppable::__internals::arithmetic
 {
-    std::string root(const std::string& _number, const std::string& base, const size_t _decimals)
+    std::string root(const std::string& _number, const std::string& base, const size_t _decimals, const int steps)
     {
-
+        if (numUtils::isDecimal(base))
+        {
+            const auto& fraction = Fraction(_number);
+            const auto& [top, bottom] = fraction.asArray();
+            const auto &powerResult = power(_number, bottom, 0), rootResult = root(powerResult, top, _decimals, 0);
+            return reportRootPower(_number, base, fraction, rootResult, steps);
+        }
 
         auto decimals = _decimals + 1;
         size_t raisedTimes = 0;

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -37,6 +37,11 @@
 
 #include <string>
 
+#ifdef WINDOWS
+    #undef max
+    #undef min
+#endif
+
 using namespace steppable::__internals::arithmetic;
 using namespace steppable::__internals::utils;
 using namespace steppable::__internals::stringUtils;

--- a/src/root/rootReport.cpp
+++ b/src/root/rootReport.cpp
@@ -36,7 +36,7 @@ std::string reportRootPower(const std::string& _number,
                             const std::string& rootResult,
                             const int steps)
 {
-    auto array = fraction.asArray();
+    const auto& array = fraction.asArray();
     std::stringstream ss;
 
     if (steps == 2)

--- a/src/root/rootReport.cpp
+++ b/src/root/rootReport.cpp
@@ -22,7 +22,32 @@
 
 #include "rootReport.hpp"
 
+#include "symbols.hpp"
+
+#include <sstream>
 #include <string>
+
+using namespace steppable::__internals::symbols;
+
+std::string reportRootPower(const std::string& _number,
+                            const std::string& base,
+                            const steppable::Fraction& fraction,
+                            const std::string& rootResult,
+                            const int steps)
+{
+    auto array = fraction.asArray();
+    std::stringstream ss;
+
+    if (steps == 2)
+        ss << "The base " << base << " is a decimal. Therefore, we need to perform a power operation first." << '\n';
+    if (steps >= 1)
+    {
+        ss << _number << makeSuperscript(static_cast<std::string>(base));
+        ss << " = " << makeSuperscript(array[1]) << makeSurd(_number + makeSuperscript(array[0])) << " = ";
+    }
+    ss << rootResult;
+    return ss.str();
+}
 
 std::string reportRoot()
 {

--- a/src/root/rootReport.cpp
+++ b/src/root/rootReport.cpp
@@ -28,6 +28,7 @@
 #include <string>
 
 using namespace steppable::__internals::symbols;
+using namespace steppable::prettyPrint::printers;
 
 std::string reportRootPower(const std::string& _number,
                             const std::string& base,
@@ -42,8 +43,8 @@ std::string reportRootPower(const std::string& _number,
         ss << "The base " << base << " is a decimal. Therefore, we need to perform a power operation first." << '\n';
     if (steps >= 1)
     {
-        ss << _number << makeSuperscript(static_cast<std::string>(base));
-        ss << " = " << makeSuperscript(array[1]) << makeSurd(_number + makeSuperscript(array[0])) << " = ";
+        ss << ppRoot(_number, base) << '\n';
+        ss << "= " << ppRoot(ppSuperscript(_number, array[0]), array[1]) << "\n= ";
     }
     ss << rootResult;
     return ss.str();

--- a/src/root/rootReport.hpp
+++ b/src/root/rootReport.hpp
@@ -22,6 +22,14 @@
 
 #pragma once
 
+#include "fraction.hpp"
+
 #include <string>
+
+std::string reportRootPower(const std::string& _number,
+                            const std::string& base,
+                            const steppable::Fraction& fraction,
+                            const std::string& rootResult,
+                            const int steps);
 
 std::string reportRoot();

--- a/src/rounding.cpp
+++ b/src/rounding.cpp
@@ -37,7 +37,7 @@ namespace steppable::__internals::numUtils
         if (number.find('.') == std::string::npos)
             return number;
         // Round off the number
-        auto splitNumberResult = splitNumber(number, "0", false, false, true, false).splitNumberArray;
+        auto splitNumberResult = splitNumber(number, "0", true, true, false, false).splitNumberArray;
         auto integer = splitNumberResult[0], decimal = splitNumberResult[1];
 
         // Preserve one digit after the rounded digit

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -26,13 +26,101 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
+
+namespace steppable::prettyPrint
+{
+    using namespace steppable::__internals::stringUtils;
+
+    ConsoleOutput::ConsoleOutput(long long height, long long width) : height(height), width(width)
+    {
+        buffer = std::vector<std::vector<char>>(height, std::vector<char>(width, ' '));
+    }
+
+    void ConsoleOutput::write(const char c, const Position& pos, bool updatePos)
+    {
+        std::vector<char> vector = buffer[pos.y];
+        vector[pos.x] = c;
+        buffer[pos.y] = vector;
+
+        if (updatePos)
+            curPos = pos;
+    }
+
+    void ConsoleOutput::write(const char c, const long long dLine, const long long dCol, bool updatePos)
+    {
+        if (dLine < 0)
+        {
+            // We need to add extra lines for printing at the very top
+            buffer.insert(buffer.begin(), -dLine, std::vector<char>(width, ' '));
+            curPos.y = 0;
+            height -= dLine;
+        }
+        if (dCol < 0)
+        {
+            for (long long i = 0; i < buffer.size(); i++)
+            {
+                std::vector<char> vector = buffer[i];
+                vector.resize(vector.size() - dCol, ' ');
+                buffer[i] = vector;
+            }
+
+            curPos.x -= dCol;
+            width -= dCol;
+        }
+        else
+            curPos.x += dCol;
+        write(c, curPos, updatePos);
+    }
+
+    void ConsoleOutput::write(const std::string& s, const Position& pos, bool updatePos)
+    {
+        Position p = pos;
+        for (const auto& c : s)
+        {
+            if (c == '\n')
+            {
+                p.y++;
+                p.x = pos.x;
+                continue;
+            }
+            write(c, p, false);
+            p.x++;
+            if (updatePos)
+                curPos = p;
+        }
+    }
+
+    std::string ConsoleOutput::asString() const
+    {
+        std::string res;
+        for (const auto& line : buffer)
+        {
+            for (const auto& c : line)
+                res += c;
+            res += '\n';
+        }
+        return res;
+    }
+
+    size_t getStringWidth(const std::string& s)
+    {
+        auto strings = split(s, '\n');
+        size_t max = 0;
+        for (const auto& string : strings)
+            max = std::max(max, string.length());
+        return max;
+    }
+
+    size_t getStringHeight(const std::string& s) { return split(s, '\n').size(); }
+} // namespace steppable::prettyPrint
 
 namespace steppable::__internals::symbols
 {
     using namespace steppable::__internals::stringUtils;
 
-    const std::array<std::string_view, 10>& SUPERSCRIPTS = { "\u2070", "\u00b9", "\u00b2", "\u00b3", "\u2074",
-                                                             "\u2075", "\u2076", "\u2077", "\u2078", "\u2079" };
+    const std::array<std::string, 10>& SUPERSCRIPTS = { "\u2070", "\u00b9", "\u00b2", "\u00b3", "\u2074",
+                                                        "\u2075", "\u2076", "\u2077", "\u2078", "\u2079" };
 
     std::string makeSubscript(const std::string& normal)
     {
@@ -56,7 +144,7 @@ namespace steppable::__internals::symbols
         return string;
     }
 
-    std::string_view makeSuperscript(const char normal)
+    std::string makeSuperscript(const char normal)
     {
         if (normal == '-')
             return "\u207B";
@@ -69,7 +157,7 @@ namespace steppable::__internals::symbols
         std::stringstream ss;
         ss << SURD;
         for (char c : radicand)
-            ss << c << COMBINE_MACRON;
+            ss << std::string(1, c) << COMBINE_MACRON;
 
         return ss.str();
     }

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -48,7 +48,10 @@ namespace steppable::__internals::symbols
     {
         std::stringstream ss;
         for (const char c : normal)
-            ss << SUPERSCRIPTS[c - '0'];
+            if (isnumber(c))
+                ss << SUPERSCRIPTS[c - '0'];
+            else
+                ss << ABOVE_DOT;
         std::string string = ss.str();
         return string;
     }
@@ -59,5 +62,15 @@ namespace steppable::__internals::symbols
             return "\u207B";
 
         return SUPERSCRIPTS[normal - '0'];
+    }
+
+    std::string makeSurd(const std::string& radicand)
+    {
+        std::stringstream ss;
+        ss << SURD;
+        for (char c : radicand)
+            ss << c << COMBINE_MACRON;
+
+        return ss.str();
     }
 } // namespace steppable::__internals::symbols

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -28,6 +28,11 @@
 #include <string>
 #include <vector>
 
+#ifdef WINDOWS
+    #undef max
+    #undef min
+#endif
+
 namespace steppable::prettyPrint
 {
     using namespace steppable::__internals::stringUtils;

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -48,7 +48,7 @@ namespace steppable::__internals::symbols
     {
         std::stringstream ss;
         for (const char c : normal)
-            if (isnumber(c))
+            if (isdigit(c))
                 ss << SUPERSCRIPTS[c - '0'];
             else
                 ss << ABOVE_DOT;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -359,3 +359,22 @@ namespace steppable::__internals::stringUtils
         return "";
     }
 } // namespace steppable::__internals::stringUtils
+
+namespace steppable::__internals::utils
+{
+    void initLocale()
+    {
+#if MS_STDLIB_BUGS
+        constexpr char cp_utf16le[] = ".1200";
+        setlocale(LC_ALL, cp_utf16le);
+        _setmode(_fileno(stdout), _O_WTEXT);
+#else
+        // The correct locale name may vary by OS, e.g., "en_US.utf8".
+        constexpr char locale_name[] = "";
+        setlocale(LC_ALL, locale_name);
+        std::locale::global(std::locale(locale_name));
+        std::wcin.imbue(std::locale());
+        std::wcout.imbue(std::locale());
+#endif
+    }
+} // namespace steppable::__internals::utils

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -128,15 +128,18 @@ namespace steppable::__internals::numUtils
         const std::vector<std::string> aParts = stringUtils::split(a, '.'), bParts = stringUtils::split(b, '.');
         auto aInteger = static_cast<std::string>(aParts.front()), aDecimal = static_cast<std::string>(aParts.back()),
              bInteger = static_cast<std::string>(bParts.front()), bDecimal = static_cast<std::string>(bParts.back());
-        // If the numbers are integers, discard their decimal points
-        if (isZeroString(aDecimal) or aParts.size() == 1)
-            aDecimal = "";
-        if (isZeroString(bDecimal) or bParts.size() == 1)
-            bDecimal = "";
-        aInteger = simplifyZeroPolarity(aInteger);
-        bInteger = simplifyZeroPolarity(bInteger);
-        aDecimal = removeTrailingZeros(aDecimal);
-        bDecimal = removeTrailingZeros(bDecimal);
+        if (properlyFormat)
+        {
+            // If the numbers are integers, discard their decimal points
+            if (isZeroString(aDecimal) or aParts.size() == 1)
+                aDecimal = "";
+            if (isZeroString(bDecimal) or bParts.size() == 1)
+                bDecimal = "";
+            aInteger = simplifyZeroPolarity(aInteger);
+            bInteger = simplifyZeroPolarity(bInteger);
+            aDecimal = removeTrailingZeros(aDecimal);
+            bDecimal = removeTrailingZeros(bDecimal);
+        }
 
         // Pad with zeros
         if (padInteger)
@@ -169,8 +172,7 @@ namespace steppable::__internals::numUtils
         if (const auto firstNonZero = std::ranges::find_if(out, [](const int num) { return num != 0; });
             out.begin() != firstNonZero && out.front() == 0)
         {
-            std::replace_if(
-                out.begin(), firstNonZero, [](const int num) { return num == 0; }, -2);
+            std::replace_if(out.begin(), firstNonZero, [](const int num) { return num == 0; }, -2);
         }
 
         return out;
@@ -237,7 +239,7 @@ namespace steppable::__internals::numUtils
 
     bool isInteger(const std::string& number)
     {
-        auto splitNumberResult = splitNumber(number, "0", false, false, false).splitNumberArray;
+        auto splitNumberResult = splitNumber(number, "0", false, false, true).splitNumberArray;
         // If the decimal part is zero, it is an integer.
         if (isZeroString(splitNumberResult[1]))
             return true;

--- a/tests/testFraction.cpp
+++ b/tests/testFraction.cpp
@@ -53,4 +53,9 @@ _.assertIsEqual((Fraction("13122", "54251") / Fraction("22451", "3423")).present
 _.assertIsEqual((Fraction("22451", "3423") / Fraction("13122", "54251")).present(), "1217989201/44916606");
 SECTION_END()
 
+SECTION(Fraction from Number)
+_.assertIsEqual(Fraction("0.25").present(), "1/4");
+_.assertIsEqual(Fraction(Number("0.25")).present(), "1/4");
+SECTION_END()
+
 TEST_END()

--- a/tests/testFraction.cpp
+++ b/tests/testFraction.cpp
@@ -55,6 +55,7 @@ SECTION_END()
 
 SECTION(Fraction from Number)
 _.assertIsEqual(Fraction("0.25").present(), "1/4");
+_.assertIsEqual(Fraction("0.5").present(), "1/2");
 _.assertIsEqual(Fraction(Number("0.25")).present(), "1/4");
 SECTION_END()
 

--- a/tests/testPower.cpp
+++ b/tests/testPower.cpp
@@ -23,6 +23,7 @@
 #include "colors.hpp"
 #include "fn/basicArithm.hpp"
 #include "output.hpp"
+#include "rounding.hpp"
 #include "testing.hpp"
 #include "util.hpp"
 
@@ -52,5 +53,12 @@ const std::string_view &number = "0.5", &raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "0.0009765625");
+SECTION_END()
+
+SECTION(Power with Decimal Exponents)
+const std::string_view &number = "4", &raiseTo = "0.5";
+const auto& result = power(number, raiseTo, 0);
+
+_.assertIsEqual(numUtils::roundOff(result), "2");
 SECTION_END()
 TEST_END()

--- a/tests/testRoot.cpp
+++ b/tests/testRoot.cpp
@@ -32,6 +32,11 @@
 TEST_START()
 SECTION(Root with a sqare number)
 using namespace steppable::__internals::arithmetic;
-_.assertIsEqual(root("4", "2"), "2.00000000");
+_.assertIsEqual(root("4", "2", 0, 0), "2");
+SECTION_END()
+
+SECTION(Root with a decimal index)
+using namespace steppable::__internals::arithmetic;
+_.assertIsEqual(root("4", "0.5", 0, 0), "16");
 SECTION_END()
 TEST_END()

--- a/tests/testUtil.cpp
+++ b/tests/testUtil.cpp
@@ -29,6 +29,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <rounding.hpp>
 
 TEST_START()
 
@@ -142,6 +143,16 @@ const std::string& in = "abcdefg";
 const auto& out = makeWider(in);
 
 _.assertIsEqual(out, "a  b  c  d  e  f  g");
+SECTION_END()
+
+SECTION(Test Rounding)
+const std::string& number1 = "1.565";
+_.assertIsEqual(roundOff(number1, 0), "2");
+_.assertIsEqual(roundOff(number1, 1), "1.6");
+
+const std::string& number2 = "1.9";
+_.assertIsEqual(roundOff(number2, 0), "2");
+_.assertIsEqual(roundOff(number2, 1), "2.0");
 SECTION_END()
 
 TEST_END()


### PR DESCRIPTION
# 1. Add support for decimal powers

For power expressions in the form of $n^{ \frac{a}{b} }$, it can be simplified into

$$ \sqrt[b]{n^a} $$

Also, the expression $\sqrt[\frac{a}{b}]{n}$ can be transformed into

$$ \sqrt[a]{n^b} $$

With the `root` component, it is possible to perform the above-mentioned operations. First, the number is converted into a fraction, and power/root operations are performed to obtain the result.

# 2. Improve rounding algorithm

The `roundOff()` method does not correctly round numbers. This PR introduces a new, reworked algorithm to allow rounding off to any desired precision.

# 3. Introducing `printer`s

The old Unicode-based printing is not flexible enough to display nested operations. It is time to switch to a SymPy-like `printer` system.

Tasks:

- [X] Add support for decimal powers.
- [x] Add support for decimal roots.
- [x] Add tests.