### PR TITLE
Improve random_test output.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,32 @@
 ---
-Checks: 'abseil-*,altera-*,bugprone-*,concurrency-*,cppcoreguidelines-*,darwin-*,fuchsia-*,readability-*,performance-*,portability-*,zircon-*,hicpp-*,google-*,cert-*,clang-diagnostic-*,clang-analyzer-*,modernize-*,-*'
+Checks: ['bugprone-*',
+        'cert-*',
+        'clang-analyzer-*',
+        'clang-diagnostic-*',
+        'concurrency-*',
+        'cppcoreguidelines-*',
+        'darwin-*',
+        'modernize-*',
+        'performance-*',
+        'portability-*',
+        'readability-*',
+        'zircon-*',
+        # Remove the following:
+        '-bugprone-easily-swappable-parameters',
+        '-bugprone-suspicious-semicolon',
+        '-cert-dcl37-c',
+        '-cert-dcl50-cpp',
+        '-cert-dcl51-cpp',
+        '-cppcoreguidelines-avoid-magic-numbers',
+        '-cppcoreguidelines-pro-bounds-array-to-pointer-decay',
+        '-cppcoreguidelines-pro-type-vararg',
+        '-modernize-use-trailing-return-type',
+        '-readability-braces-around-statements',
+        '-readability-identifier-length',
+        '-readability-magic-numbers',
+    ]
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle: Microsoft
 User: coder
 CheckOptions:
@@ -24,5 +48,7 @@ CheckOptions:
   modernize-loop-convert.NamingStyle: CamelCase
   llvm-else-after-return.WarnOnUnfixable: 'false'
   google-readability-function-size.StatementThreshold: '800'
+  bugprone-reserved-identifier.AllowedIdentifiers: '__internals'
+  readability-function-cognitive-complexity.Threshold: 40
 ...
 

--- a/.clangd
+++ b/.clangd
@@ -2,5 +2,39 @@ CompileFlags:
   Add: -std=c++20
 Diagnostics:
   ClangTidy:
-    Add: modernize*
-    Remove: modernize-use-trailing-return-type
+    Add: ['bugprone-*',
+        'concurrency-*',
+        'cppcoreguidelines-*',
+        'darwin-*',
+        'readability-*',
+        'performance-*',
+        'portability-*',
+        'zircon-*',
+        'cert-*',
+        'clang-diagnostic-*',
+        'clang-analyzer-*',
+        'modernize-*']
+    CheckOptions:
+      'bugprone-reserved-identifier.AllowedIdentifiers': '__internals'
+      'readability-function-cognitive-complexity.Threshold': 40
+
+    Remove: [
+        'modernize-use-trailing-return-type',
+        'cppcoreguidelines-avoid-magic-numbers',
+        'readability-magic-numbers',
+        'bugprone-easily-swappable-parameters',
+        'cert-dcl50-cpp',
+        'cert-dcl37-c',
+        'cert-dcl51-cpp',
+        'cppcoreguidelines-pro-type-vararg',
+        'readability-braces-around-statements',
+        'readability-identifier-length'
+    ]
+
+---
+# Disable include-what-you-use for test files
+If:
+  PathMatch: test.*\.cpp
+
+Diagnostics:
+  UnusedIncludes: None

--- a/.cmake-format
+++ b/.cmake-format
@@ -211,7 +211,7 @@ with section("format"):  # pyright: ignore
 
     # If a statement is wrapped to more than one line, than dangle the closing
     # parenthesis on its own line.
-    dangle_parens = False
+    dangle_parens = True
 
     # If the trailing parenthesis must be 'dangled' on its on line, then align it
     # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
@@ -236,7 +236,7 @@ with section("format"):  # pyright: ignore
     line_ending = "unix"
 
     # Format command names consistently as 'lower' or 'upper' case
-    command_case = "lower"
+    command_case = "upper"
 
     # Format keywords consistently as 'lower' or 'upper' case
     keyword_case = "upper"
@@ -275,7 +275,7 @@ with section("markup"):  # pyright: ignore
     # If comment markup is enabled, don't reflow the first comment block in each
     # listfile. Use this to preserve formatting of your copyright/license
     # statements.
-    first_comment_is_literal = False
+    first_comment_is_literal = True
 
     # If comment markup is enabled, don't reflow any comment block which matches
     # this (regex) pattern. Default is `None` (disabled).

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,7 +4,7 @@ name: CMake on multiple platforms
 
 on:
     push:
-        branches: [ "main", "develop" ]
+        branches: [ "develop" ]
     pull_request:
         branches: [ "main" ]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+# This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+name: Lint
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: Install LLVM
+      run: |
+        brew install llvm
+        echo "/opt/homebrew/opt/llvm/bin:$GITHUB_PATH" > $GITHUB_PATH
+
+    - name: Setup Python
+      uses: actions/setup-python@v5.1.0
+      with:
+        # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.
+        python-version: '3.12'
+
+    - name: Install packages
+      run: pip install -r ${{github.workspace}}/requirements.txt
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+    - name: Lint
+      run: python3 tools/run_clang_tidy.py -source-filter='.*lib.*' -p build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,93 +20,117 @@
 #  SOFTWARE.                                                                                        #
 #####################################################################################################
 
-cmake_minimum_required(VERSION 3.20)
-project(Steppable)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.20)
+PROJECT(Steppable)
 
 # Ensure that Python is available to run the development scripts, and build with bindings.
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+FIND_PACKAGE(
+    Python
+    COMPONENTS Interpreter Development
+    REQUIRED
+)
+FIND_PACKAGE(
+    Python3
+    COMPONENTS Interpreter Development
+    REQUIRED
+)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+SET(CMAKE_CXX_STANDARD 20)
+SET(CMAKE_CXX_EXTENSIONS OFF)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(STP_BASE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} CACHE STRING "The source directory of Steppable")
+SET(STP_BASE_DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    CACHE STRING "The source directory of Steppable"
+)
 
+EXECUTE_PROCESS(
+    COMMAND uname -o
+    COMMAND tr -d '\n'
+    OUTPUT_VARIABLE OPERATING_SYSTEM
+)
+IF(${OPERATING_SYSTEM} MATCHES "Android")
+    SET(ANDROID 1)
+    MESSAGE(STATUS "Building for Android.")
+    SET(LINUX CACHE INTERNAL "Is Linux or Android" 1)
+ENDIF()
 
-execute_process(COMMAND uname -o COMMAND tr -d '\n' OUTPUT_VARIABLE OPERATING_SYSTEM)
-if (${OPERATING_SYSTEM} MATCHES "Android")
-    set(ANDROID 1)
-    message(STATUS "Building for Android.")
-    set(LINUX CACHE INTERNAL "Is Linux or Android" 1)
-endif ()
+IF(WIN32)
+    ADD_COMPILE_DEFINITIONS(WINDOWS)
+    IF(MSVC) # MSVC Has no UTF-8 support by default
+        ADD_COMPILE_OPTIONS(/utf-8)
+    ENDIF()
+    SET(WINDOWS TRUE)
+ELSEIF(APPLE)
+    ADD_COMPILE_DEFINITIONS(MACOSX)
+ELSEIF(LINUX)
+    ADD_COMPILE_DEFINITIONS(LINUX)
+ELSE()
+    MESSAGE(ERROR "Platform not defined")
+ENDIF()
 
-if (WIN32)
-    add_compile_definitions(WINDOWS)
-    if (MSVC) # MSVC Has no UTF-8 support by default
-        add_compile_options(/utf-8)
-    endif ()
-    set(WINDOWS TRUE)
-elseif (APPLE)
-    add_compile_definitions(MACOSX)
-elseif (LINUX)
-    add_compile_definitions(LINUX)
-else ()
-    message(ERROR "Platform not defined")
-endif ()
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    ADD_COMPILE_DEFINITIONS(DEBUG)
+    SET(DEBUG TRUE)
+ENDIF()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_compile_definitions(DEBUG)
-    set(DEBUG TRUE)
-endif ()
+FUNCTION(capitalize IN OUT)
+    STRING(SUBSTRING ${IN} 0 1 FIRST_LETTER)
+    STRING(SUBSTRING ${IN} 1 -1 THE_REST)
+    STRING(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
+    STRING(CONCAT CAPITALIZED ${FIRST_LETTER} ${THE_REST})
+    SET(${OUT}
+        ${CAPITALIZED}
+        PARENT_SCOPE
+    )
+ENDFUNCTION()
 
-function(capitalize IN OUT)
-    string(SUBSTRING ${IN} 0 1 FIRST_LETTER)
-    string(SUBSTRING ${IN} 1 -1 THE_REST)
-    string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
-    string(CONCAT CAPITALIZED ${FIRST_LETTER} ${THE_REST})
-    set(${OUT}
-            ${CAPITALIZED}
-            PARENT_SCOPE)
-endfunction()
+SET(COMPONENTS
+    abs
+    add
+    baseConvert
+    subtract
+    multiply
+    decimalConvert
+    comparison
+    power
+    division
+    root
+)
+# NEW_COMPONENT: PATCH Do NOT remove the previous comment.
 
-set(COMPONENTS abs add baseConvert subtract multiply decimalConvert comparison power division root)
-# NEW_COMPONENT: PATCH
-# Do NOT remove the previous comment.
+SET(TARGETS ${COMPONENTS} util)
+SET(TEST_TARGETS_TEMP util fraction number factors ${COMPONENTS})
 
-set(TARGETS ${COMPONENTS} util)
-set(TEST_TARGETS_TEMP util fraction number ${COMPONENTS})
+FOREACH(TEST_TARGET IN LISTS TEST_TARGETS_TEMP)
+    SET(TARGET_NAME "test")
+    CAPITALIZE(${TEST_TARGET} FILE_NAME)
+    STRING(CONCAT TARGET_NAME ${TARGET_NAME} ${FILE_NAME})
+    LIST(APPEND TEST_TARGETS ${TARGET_NAME})
+ENDFOREACH()
 
-foreach (TEST_TARGET IN LISTS TEST_TARGETS_TEMP)
-    set(TARGET_NAME "test")
-    capitalize(${TEST_TARGET} FILE_NAME)
-    string(CONCAT TARGET_NAME ${TARGET_NAME} ${FILE_NAME})
-    list(APPEND TEST_TARGETS ${TARGET_NAME})
-endforeach ()
+ADD_SUBDIRECTORY(src/)
+ADD_SUBDIRECTORY(lib/)
+ADD_SUBDIRECTORY(tests/)
+ADD_SUBDIRECTORY(include/) # The CMakeLists file there adds the include/ directory to everything
 
-add_subdirectory(src/)
-add_subdirectory(lib/)
-add_subdirectory(tests/)
-add_subdirectory(include/) # The CMakeLists file there adds the include/ directory to everything
+FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-
-
-if (DEBUG)
+IF(DEBUG)
     # Patch the compile_commands.json using the Python script
-    add_custom_target(
-            fix_ccjson ALL
-            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/patch_compile_commands.py
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "Patching compile_commands.json"
+    ADD_CUSTOM_TARGET(
+        fix_ccjson ALL
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/patch_compile_commands.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Patching compile_commands.json"
     )
 
-    add_custom_target(
-            add_header_comments ALL
-            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/add_copyright_header.py
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            COMMENT "Adding header comments"
+    ADD_CUSTOM_TARGET(
+        add_header_comments ALL
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/add_copyright_header.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Adding header comments"
     )
-endif ()
+ENDIF()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -21,6 +21,6 @@
 #####################################################################################################
 
 # Add include directory to all targets
-foreach (TARGET IN LISTS TEST_TARGETS)
-    target_include_directories(${TARGET} PUBLIC ${STP_BASE_DIRECTORY}/include/)
-endforeach (TARGET)
+FOREACH(TARGET IN LISTS TEST_TARGETS)
+    TARGET_INCLUDE_DIRECTORIES(${TARGET} PUBLIC ${STP_BASE_DIRECTORY}/include/)
+ENDFOREACH(TARGET)

--- a/include/argParse.hpp
+++ b/include/argParse.hpp
@@ -54,11 +54,11 @@ namespace steppable::__internals::utils
 
     /// @brief This is the correct format of a keyword argument.
     // language=RegExp
-    [[maybe_unused]] static const std::regex KEYWORD_ARG_REGEX(R"(^-([a-zA-Z]*):(-?[0-9]+)$)");
+    [[maybe_unused]] const std::regex KEYWORD_ARG_REGEX(R"(^-([a-zA-Z]*):(-?[0-9]+)$)");
 
     /// @brief This is the correct format of a switch.
     // language=RegExp
-    [[maybe_unused]] static const std::regex SWITCH_REGEX(R"(^([-+])([a-zA-Z]*)$)");
+    [[maybe_unused]] const std::regex SWITCH_REGEX(R"(^([-+])([a-zA-Z]*)$)");
 
     /**
      * @class ProgramArgs

--- a/include/exceptions.hpp
+++ b/include/exceptions.hpp
@@ -31,8 +31,6 @@
 #pragma once
 
 #include <exception>
-#include <string>
-#include <utility>
 
 namespace steppable::exceptions
 {

--- a/include/factors.hpp
+++ b/include/factors.hpp
@@ -20,32 +20,44 @@
  * SOFTWARE.                                                                                      *
  **************************************************************************************************/
 
-#include "colors.hpp"
-#include "fn/basicArithm.hpp"
-#include "output.hpp"
-#include "testing.hpp"
-#include "util.hpp"
+#pragma once
 
-#include <iomanip>
-#include <iostream>
+#include <string>
+#include <vector>
 
-TEST_START()
+namespace steppable::__internals::numUtils
+{
+    /**
+     * @brief Get the factors of a number.
+     *
+     * @param[in] _number The number to get the factors of.
+     * @return The factors of the number.
+     */
+    std::vector<std::string> getFactors(const std::string& _number);
 
-using namespace steppable::__internals::arithmetic;
+    /**
+     * @brief Get the largest factor of a number, that is a root number.
+     *
+     * @param[in] _number The number to get the largest root factor of.
+     * @param[in] base The base of the root.
+     * @return The largest root factor of the number.
+     */
+    std::string getRootFactor(const std::string& _number, const std::string& base = "2");
 
-SECTION(Decimal Convert without letters)
-const std::string &a = "46432231133131";
-const std::string &b = "8";
-const auto& result = decimalConvert(a, b, 0);
+    /**
+     * @brief Get the greatest root number less than or equal to the given number.
+     *
+     * @param[in] _number The number to get the greatest root number of.
+     * @param[in] base The base of the root.
+     * @return The greatest root number less than or equal to the given number.
+     */
+    std::string getGreatestRootNum(const std::string& _number, const std::string& base = "2");
 
-_.assertIsEqual(result, "2649229669977");
-SECTION_END()
-
-SECTION(Decimal Convert)
-const std::string &a = "88a";
-const std::string &b = "16";
-const auto& result = decimalConvert(a, b, 0);
-
-_.assertIsEqual(result, "2186");
-SECTION_END()
-TEST_END()
+    /**
+     * @brief Check if a number is prime.
+     *
+     * @param[in] _number The number to check.
+     * @return True if the number is prime, false otherwise.
+     */
+    bool isPrime(const std::string& _number);
+} // namespace steppable::__internals::numUtils

--- a/include/factors.hpp
+++ b/include/factors.hpp
@@ -60,4 +60,13 @@ namespace steppable::__internals::numUtils
      * @return True if the number is prime, false otherwise.
      */
     bool isPrime(const std::string& _number);
+
+    /**
+     * @brief Check if a number is a root number.
+     *
+     * @param[in] _number The number to check.
+     * @param[in] base The base of the root.
+     * @return True if the number is a root number, false otherwise.
+     */
+    bool isRoot(const std::string& _number, const std::string& base);
 } // namespace steppable::__internals::numUtils

--- a/include/factors.hpp
+++ b/include/factors.hpp
@@ -22,8 +22,12 @@
 
 #pragma once
 
+#include "types/result.hpp"
+
 #include <string>
 #include <vector>
+
+using namespace steppable::types;
 
 namespace steppable::__internals::numUtils
 {
@@ -40,9 +44,9 @@ namespace steppable::__internals::numUtils
      *
      * @param[in] _number The number to get the largest root factor of.
      * @param[in] base The base of the root.
-     * @return The largest root factor of the number.
+     * @return A result object containing the largest root factor of the number.
      */
-    std::string getRootFactor(const std::string& _number, const std::string& base = "2");
+    ResultBool getRootFactor(const std::string& _number, const std::string& base = "2");
 
     /**
      * @brief Get the greatest root number less than or equal to the given number.
@@ -66,7 +70,8 @@ namespace steppable::__internals::numUtils
      *
      * @param[in] _number The number to check.
      * @param[in] base The base of the root.
-     * @return True if the number is a root number, false otherwise.
+     * @return StatusBool::CALCULATED_SIMPLIFIED_YES if the number is a root number,
+     * StatusBool::CALCULATED_SIMPLIFIED_NO otherwise.
      */
-    bool isRoot(const std::string& _number, const std::string& base);
+    ResultBool isRoot(const std::string& _number, const std::string& base);
 } // namespace steppable::__internals::numUtils

--- a/include/fn/basicArithm.hpp
+++ b/include/fn/basicArithm.hpp
@@ -36,6 +36,7 @@
 #pragma once
 
 #include "output.hpp"
+#include "util.hpp"
 
 #include <string>
 #include <string_view>
@@ -55,7 +56,7 @@ namespace steppable::__internals::arithmetic
     {
         std::string quotient;
         std::string remainder;
-    };
+    } ALIGN64;
 
     /**
      * @brief Calculates the absolute value of a string representation of a number.
@@ -114,7 +115,7 @@ namespace steppable::__internals::arithmetic
      * @param[in] steps The number of steps to perform the conversion.
      * @return The converted number as a string.
      */
-    std::string baseConvert(const std::string_view& _number, const std::string_view& baseStr, const int steps = 2);
+    std::string baseConvert(const std::string_view& _number, const std::string_view& baseStr, int steps = 2);
 
     /**
      * @brief Divides a string representation of a number by another string representation of a number.
@@ -190,7 +191,17 @@ namespace steppable::__internals::arithmetic
      *
      * @return The result of the root operation.
      */
-    std::string root(const std::string& _number, const std::string& base, const size_t decimals = 8, const int steps = 2);
+    std::string root(const std::string& _number, const std::string& base, size_t decimals = 8, int steps = 2);
+
+    /**
+     * @brief Gets the integer part of the root of a number.
+     *
+     * @param _number The number to get the root of.
+     * @param base The base of the root.
+     *
+     * @return The integer part of the root of the number.
+     */
+    std::string rootIntPart(const std::string& _number, const std::string& base);
 
     /**
      * @brief Executes a given predicate function a specified number of times.

--- a/include/fn/basicArithm.hpp
+++ b/include/fn/basicArithm.hpp
@@ -35,8 +35,8 @@
 
 #pragma once
 
+#include "fn/root.hpp"
 #include "output.hpp"
-#include "util.hpp"
 
 #include <string>
 #include <string_view>
@@ -56,7 +56,7 @@ namespace steppable::__internals::arithmetic
     {
         std::string quotient;
         std::string remainder;
-    } ALIGN64;
+    };
 
     /**
      * @brief Calculates the absolute value of a string representation of a number.
@@ -192,6 +192,15 @@ namespace steppable::__internals::arithmetic
      * @return The result of the root operation.
      */
     std::string root(const std::string& _number, const std::string& base, size_t decimals = 8, int steps = 2);
+
+    /**
+     * @brief Converts a root operation into a surd.
+     *
+     * @param _number The number to convert to a surd.
+     * @param base The base of the root.
+     * @return The surd object.
+     */
+    Surd rootSurd(const std::string& _number, const std::string& base);
 
     /**
      * @brief Gets the integer part of the root of a number.

--- a/include/fn/basicArithm.hpp
+++ b/include/fn/basicArithm.hpp
@@ -191,7 +191,7 @@ namespace steppable::__internals::arithmetic
      *
      * @return The result of the root operation.
      */
-    std::string root(const std::string& _number, const std::string& base, size_t decimals = 8, int steps = 2);
+    std::string root(const std::string& _number, const std::string& base, size_t decimals = 8);
 
     /**
      * @brief Converts a root operation into a surd.

--- a/include/fn/root.hpp
+++ b/include/fn/root.hpp
@@ -20,39 +20,22 @@
  * SOFTWARE.                                                                                      *
  **************************************************************************************************/
 
-#include "colors.hpp"
-#include "factors.hpp"
-#include "output.hpp"
-#include "testing.hpp"
-#include "util.hpp"
+#pragma once
 
-#include <iomanip>
-#include <iostream>
+#include <string>
 
-TEST_START()
-using namespace steppable::__internals::numUtils;
+namespace steppable::__internals::arithmetic
+{
+    /**
+     * @brief A struct to represent a surd.
+     * A surd is a number that cannot be simplified to remove a square root. It is expressed as \f$(a\sqrt[n]{b})\f$.
+     */
+    struct Surd
+    {
+        /// @brief The radicand of the surd.
+        std::string radicand;
 
-SECTION(Prime Test)
-_.assertTrue(isPrime("2"));
-_.assertTrue(isPrime("3"));
-_.assertFalse(isPrime("16"));
-_.assertFalse(isPrime("100"));
-_.assertFalse(isPrime("1000"));
-_.assertFalse(isPrime("10000"));
-SECTION_END()
-
-SECTION(Greatest Square Number Test)
-_.assertIsEqual(getGreatestRootNum("2"), "1");
-_.assertIsEqual(getGreatestRootNum("3"), "1");
-_.assertIsEqual(getGreatestRootNum("4"), "4");
-_.assertIsEqual(getGreatestRootNum("5"), "4");
-SECTION_END()
-
-SECTION(Greatest Root Factor Test)
-_.assertIsEqual(getRootFactor("24", "2"), "4");
-_.assertIsEqual(getRootFactor("13", "2"), "1");
-_.assertIsEqual(getRootFactor("27", "2"), "9");
-_.assertIsEqual(getRootFactor("72", "2"), "36");
-SECTION_END()
-
-TEST_END()
+        /// @brief The multiplier of the surd.
+        std::string multiplier;
+    };
+} // namespace steppable::__internals::arithmetic

--- a/include/format.hpp
+++ b/include/format.hpp
@@ -76,10 +76,10 @@ namespace steppable::__internals::format
 
         // Return a formatted string without risking memory mismanagement
         // and without assuming any compiler or platform specific behavior
-        std::vector<CharT> zc(iLen + 1);
-        std::vsnprintf(zc.data(), zc.size(), zcFormat, vaArgs);
+        std::vector<CharT> formatted(iLen + 1);
+        (void)std::vsnprintf(formatted.data(), formatted.size(), zcFormat, vaArgs);
         va_end(vaArgs);
-        return std::string(zc.data(), zc.size());
+        return std::string(formatted.data(), formatted.size());
     }
 
     /**
@@ -99,18 +99,18 @@ namespace steppable::__internals::format
     {
         const CharT* const zcFormat = sFormat;
 
-        va_list vaArgs;
+        va_list vaArgs = nullptr;
         va_start(vaArgs, sFormat);
 
-        va_list vaCopy;
+        va_list vaCopy = nullptr;
         va_copy(vaCopy, vaArgs);
         const int iLen = std::vsnprintf(nullptr, 0, zcFormat, vaCopy); // NOLINT(clang-diagnostic-format-nonliteral)
         va_end(vaCopy);
 
-        std::vector<CharT> zc(iLen + 1);
-        static_cast<void>(
-            std::vsnprintf(zc.data(), zc.size(), zcFormat, vaArgs)); // NOLINT(clang-diagnostic-format-nonliteral)
+        std::vector<CharT> formatted(iLen + 1);
+        static_cast<void>(std::vsnprintf(
+            formatted.data(), formatted.size(), zcFormat, vaArgs)); // NOLINT(clang-diagnostic-format-nonliteral)
         va_end(vaArgs);
-        return std::string(zc.data(), zc.size());
+        return std::string(formatted.data(), formatted.size());
     }
 } // namespace steppable::__internals::format

--- a/include/format.hpp
+++ b/include/format.hpp
@@ -64,12 +64,12 @@ namespace steppable::__internals::format
         const CharT* const zcFormat = sFormat.c_str();
 
         // Initialize a variable argument array
-        va_list vaArgs;
+        va_list vaArgs; // NOLINT(cppcoreguidelines-init-variables)
         va_start(vaArgs, sFormat);
 
         // Reliably acquire the size from a copy of the variable argument array
         // and a functionally reliable call to mock the formatting
-        va_list vaCopy;
+        va_list vaCopy; // NOLINT(cppcoreguidelines-init-variables)
         va_copy(vaCopy, vaArgs);
         const int iLen = std::vsnprintf(nullptr, 0, zcFormat, vaCopy);
         va_end(vaCopy);
@@ -99,10 +99,10 @@ namespace steppable::__internals::format
     {
         const CharT* const zcFormat = sFormat;
 
-        va_list vaArgs = nullptr;
+        va_list vaArgs; // NOLINT(cppcoreguidelines-init-variables)
         va_start(vaArgs, sFormat);
 
-        va_list vaCopy = nullptr;
+        va_list vaCopy; // NOLINT(cppcoreguidelines-init-variables)
         va_copy(vaCopy, vaArgs);
         const int iLen = std::vsnprintf(nullptr, 0, zcFormat, vaCopy); // NOLINT(clang-diagnostic-format-nonliteral)
         va_end(vaCopy);

--- a/include/fraction.hpp
+++ b/include/fraction.hpp
@@ -56,14 +56,14 @@ namespace steppable
          * @note By default, the top and bottom components are 1.
          * @throws ZeroDenominatorException when the bottom component is zero.
          */
-        Fraction(const std::string& top = "1", const std::string& bottom = "1");
+        explicit Fraction(const std::string& top = "1", const std::string& bottom = "1");
 
         /**
          * @brief Initialized a fraction from a number.
          *
          * @param number The number to convert to a fraction.
          */
-        Fraction(const Number& number);
+        explicit Fraction(const Number& number);
 
         /**
          * @brief Initializes a fraction with no top component and bottom component specified.
@@ -78,13 +78,13 @@ namespace steppable
          * @param inLine Whether to present the fraction in a single line.
          * @return The fraction as a string.
          */
-        std::string present(const bool inLine = true);
+        std::string present(bool inLine = true);
 
         /**
          * @brief Returns the fraction as an array of its top and bottom components.
          * @return The array of top and bottom components.
          */
-        std::array<std::string, 2> asArray() const;
+        [[nodiscard]] std::array<std::string, 2> asArray() const;
 
         /**
          * @brief Adds two fractions together.

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -84,7 +84,7 @@ namespace steppable::__internals::logging
  * @param[in] level The logging level (default: Level::INFO).
  */
 #if DEBUG
-        Logger(const std::string& name, const std::string& filename, const Level level = Level::DBG);
+        Logger(const std::string& name, const std::string& filename, Level level = Level::DBG);
 #else
         Logger(const std::string& name, const std::string& filename, const Level level = Level::INFO);
 #endif
@@ -106,7 +106,7 @@ namespace steppable::__internals::logging
          * @param[in] args The additional arguments.
          */
         template<typename... Args>
-        void error(const std::string& message, Args&&... args)
+        void error(const std::string& message, Args... args)
         {
             auto formattedMsg = vFormat(message, args...);
             error(formattedMsg);
@@ -124,7 +124,7 @@ namespace steppable::__internals::logging
          * @param[in] args The additional arguments.
          */
         template<typename... Args>
-        void warning(const std::string& message, Args&&... args)
+        void warning(const std::string& message, Args... args)
         {
             auto formattedMsg = vFormat(message, args...);
             warning(formattedMsg);
@@ -148,7 +148,7 @@ namespace steppable::__internals::logging
          * @param[in] args The additional arguments.
          */
         template<typename... Args>
-        void debug(const std::string& message, Args&&... args)
+        void debug(const std::string& message, Args... args)
         {
             auto formattedMsg = vFormat(message, args...);
             debug(formattedMsg);

--- a/include/number.hpp
+++ b/include/number.hpp
@@ -84,7 +84,7 @@ namespace steppable
          * @brief Initializes a number with a specified value.
          * @note By default, the value is 0.
          */
-        Number(const std::string& value = "0", size_t prec = 0, RoundingMode mode = USE_CURRENT_PREC);
+        Number(std::string value = "0", size_t prec = 0, RoundingMode mode = USE_CURRENT_PREC);
 
         /**
          * @brief Adds two numbers together.
@@ -228,6 +228,6 @@ namespace steppable
          * @brief Presents the number in a human-readable format.
          * @return The number as a string.
          */
-        std::string present() const;
+        [[nodiscard]] std::string present() const;
     };
 } // namespace steppable

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -122,7 +122,6 @@ namespace steppable::output
      *
      * @tparam T The character type of the message.
      * @tparam Args The types of the additional arguments.
-     * @param[in] name The name of the error.
      * @param[in] msg The error message.
      * @param[in] args Additional arguments for formatting the message.
      */
@@ -145,7 +144,6 @@ namespace steppable::output
      *
      * @tparam T The character type of the message.
      * @tparam Args The types of the additional arguments.
-     * @param[in] name The name of the info message.
      * @param[in] msg The info message.
      * @param[in] args Additional arguments for formatting the message.
      */

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -55,6 +55,7 @@ namespace steppable::output
 {
     using namespace steppable::__internals;
     using namespace steppable::__internals::utils;
+    using namespace steppable::__internals::symbols;
 
     /**
      * @brief Prints an error message.
@@ -73,10 +74,10 @@ namespace steppable::output
      * @param[in] args Additional arguments for formatting the message.
      */
     template<typename T, typename... Args>
-    void error(const std::string& name, std::basic_string<T> msg, Args&&... args)
+    void error(const std::string& name, std::basic_string<T> msg, Args... args)
     {
         auto formattedMsg = format::vFormat(std::string(msg), args...);
-        std::cerr << colors::red << formats::bold << LARGE_DOT " Error: " << reset << colors::red;
+        std::cerr << colors::red << formats::bold << LARGE_DOT << " Error: " << reset << colors::red;
         std::cerr << formattedMsg << reset << '\n';
 
         // Write to the log file
@@ -101,7 +102,7 @@ namespace steppable::output
     template<typename CharT>
     void error(const std::string& name, std::basic_string<CharT> msg)
     {
-        std::cerr << colors::red << formats::bold << LARGE_DOT " Error: " << reset << colors::red;
+        std::cerr << colors::red << formats::bold << LARGE_DOT << " Error: " << reset << colors::red;
         std::cerr << msg << reset << '\n';
 
         // Write to the log file
@@ -126,9 +127,9 @@ namespace steppable::output
      * @param[in] args Additional arguments for formatting the message.
      */
     template<typename T, typename... Args>
-    [[maybe_unused]] void warning(T msg, Args&&... args)
+    [[maybe_unused]] void warning(T msg, Args... args)
     {
-        std::cout << colors::yellow << formats::bold << LARGE_DOT " Warning: " << reset << colors::yellow;
+        std::cout << colors::yellow << formats::bold << LARGE_DOT << " Warning: " << reset << colors::yellow;
         std::cout << format::vFormat(msg, args...) << reset << '\n';
     }
 
@@ -149,9 +150,9 @@ namespace steppable::output
      * @param[in] args Additional arguments for formatting the message.
      */
     template<typename T, typename... Args>
-    void info(T msg, Args&&... args)
+    void info(T msg, Args... args)
     {
-        std::cout << colors::brightGreen << formats::bold << LARGE_DOT " Info: " << reset << colors::brightGreen;
+        std::cout << colors::brightGreen << formats::bold << LARGE_DOT << " Info: " << reset << colors::brightGreen;
         std::cout << format::vFormat(msg, args...) << reset << '\n';
     }
 } // namespace steppable::output

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -56,7 +56,7 @@ namespace steppable::__internals::utils
     inline void programSafeExit(const int status)
     {
 #ifdef MACOSX
-        exit(status);
+        exit(status); // NOLINT(concurrency-mt-unsafe)
 #else
         std::quick_exit(status);
 #endif
@@ -72,7 +72,7 @@ namespace steppable::__internals::utils
 #else
         static std::mutex mtx;
         std::lock_guard<std::mutex> lock(mtx);
-        bt = *std::localtime(timer);
+        bt = *std::localtime(timer); // NOLINT(concurrency-mt-unsafe)
 #endif
         return bt;
     }

--- a/include/rounding.hpp
+++ b/include/rounding.hpp
@@ -26,13 +26,29 @@
 namespace steppable::__internals::numUtils
 {
     /**
+     * @brief Round down a number to the nearest integer.
+     *
+     * @param[in] _number The number to round down.
+     * @return The rounded number.
+     */
+    std::string roundDown(const std::string& _number);
+
+    /**
+     * @brief Round up a number to the nearest integer.
+     *
+     * @param[in] _number The number to round up.
+     * @return The rounded number.
+     */
+    std::string roundUp(const std::string& _number);
+
+    /**
      * @brief Round off a number to the nearest integer.
      *
      * @param[in] _number The number to round.
      * @param[in] digits The number of decimal places to round to.
      * @return The rounded number.
      */
-    std::string roundOff(const std::string& _number, const size_t digits = 0);
+    std::string roundOff(const std::string& _number, size_t digits = 0);
 
     /**
      * @brief Move the decimal places of a number.
@@ -43,5 +59,5 @@ namespace steppable::__internals::numUtils
      *
      * @return The processed number.
      */
-    std::string moveDecimalPlaces(const std::string& _number, const long places);
+    std::string moveDecimalPlaces(const std::string& _number, long places);
 } // namespace steppable::__internals::numUtils

--- a/include/symbols.hpp
+++ b/include/symbols.hpp
@@ -35,11 +35,7 @@
 #include <array>
 #include <cstddef>
 #include <string>
-#include <vector>
-
-#pragma once
-
-#include <string>
+#include <string_view>
 #include <vector>
 
 /**
@@ -55,7 +51,7 @@ namespace steppable::prettyPrint
     {
         long long x = 0;
         long long y = 0;
-    };
+    } __attribute__((aligned(16)));
 
     // // Not currently in use.
     // enum PrintingAlignment
@@ -83,10 +79,10 @@ namespace steppable::prettyPrint
         std::vector<std::vector<char>> buffer;
 
         /// @brief The height of the buffer.
-        long long height = 10;
+        size_t height = 10;
 
         /// @brief The width of the buffer.
-        long long width = 10;
+        size_t width = 10;
 
     public:
         /**
@@ -95,7 +91,7 @@ namespace steppable::prettyPrint
          * @param height The height of the buffer.
          * @param width The width of the buffer.
          */
-        ConsoleOutput(long long height, long long width);
+        ConsoleOutput(size_t height, size_t width);
 
         /**
          * @brief Writes a character to the buffer.
@@ -105,7 +101,7 @@ namespace steppable::prettyPrint
          * @param dCol The change in column.
          * @param updatePos Whether to update the current position.
          */
-        void write(const char c, const long long dLine, const long long dCol, bool updatePos = false);
+        void write(char c, long long dLine, long long dCol, bool updatePos = false);
 
         /**
          * @brief Writes a character to the buffer.
@@ -114,7 +110,7 @@ namespace steppable::prettyPrint
          * @param pos The position to write to.
          * @param updatePos Whether to update the current position.
          */
-        void write(const char c, const Position& pos, bool updatePos = false);
+        void write(char c, const Position& pos, bool updatePos = false);
 
         /**
          * @brief Writes a string to the buffer.
@@ -161,39 +157,39 @@ namespace steppable::prettyPrint
  */
 namespace steppable::__internals::symbols
 {
-/// @brief The because symbol (3 dots in a triangle, Unicode U+2235)
-#define BECAUSE "\u2235"
-/// @brief The therefore symbol (3 dots in a triangle, Unicode U+2234)
-#define THEREFORE "\u2234"
+    /// @brief The because symbol (3 dots in a triangle, Unicode U+2235)
+    constexpr std::string_view BECAUSE = "\u2235";
+    /// @brief The therefore symbol (3 dots in a triangle, Unicode U+2234)
+    constexpr std::string_view THEREFORE = "\u2234";
 
-/// @brief The multiply symbol (Unicode U+00D7)
-#define MULTIPLY "\u00D7"
-/// @brief The divide symbol (Unicode U+00F7)
-#define DIVIDED_BY "\u00F7"
+    /// @brief The multiply symbol (Unicode U+00D7)
+    constexpr std::string_view MULTIPLY = "\u00D7";
+    /// @brief The divide symbol (Unicode U+00F7)
+    constexpr std::string_view DIVIDED_BY = "\u00F7";
 
-#define SURD "\u221A"
-#define COMBINE_MACRON "\u0305"
+    constexpr std::string_view SURD = "\u221A";
+    constexpr std::string_view COMBINE_MACRON = "\u0305";
 
-/// @brief The large dot symbol (Unicode U+25C9)
-#define LARGE_DOT "\u25C9"
-#define ABOVE_DOT "\u02D9"
+    /// @brief The large dot symbol (Unicode U+25C9)
+    constexpr std::string_view LARGE_DOT = "\u25C9";
+    constexpr std::string_view ABOVE_DOT = "\u02D9";
 
-// Subscripts
-/**
- * @brief The subscript 0 (Unicode U+2080)
- * @note This is used to check if a subscript is converted correctly, do not use this in the program.
- */
-#define SUB_0 "\u2080"
-/**
- * @brief The subscript z (Unicode U+2098)
- * @note This is used to check if a subscript is converted correctly, do not use this in the program.
- */
-#define SUB_Z "\u1D69"
-/**
- * @brief The subscript magic number (8272)
- * @note This is used to check if a subscript is converted correctly, do not use this in the program.
- */
-#define SUB_MAGIC_NUMBER 8272
+    // Subscripts
+    /**
+     * @brief The subscript 0 (Unicode U+2080)
+     * @note This is used to check if a subscript is converted correctly, do not use this in the program.
+     */
+    constexpr std::string_view SUB_0 = "\u2080";
+    /**
+     * @brief The subscript z (Unicode U+2098)
+     * @note This is used to check if a subscript is converted correctly, do not use this in the program.
+     */
+    constexpr std::string_view SUB_Z = "\u1D69";
+    /**
+     * @brief The subscript magic number (8272)
+     * @note This is used to check if a subscript is converted correctly, do not use this in the program.
+     */
+    constexpr int SUB_MAGIC_NUMBER = 8272;
 
     /// @brief A list of subscript characters.
     extern const std::array<std::string, 10>& SUPERSCRIPTS;
@@ -214,22 +210,22 @@ namespace steppable::__internals::symbols
      */
     std::string makeSubscript(int normal);
 
-// Superscripts
-/**
- * @brief The superscript 0 (Unicode U+2070)
- * @note This is used to check if a superscript is converted correctly, do not use this in the program.
- */
-#define SUP_0 "\u2070"
-/**
- * @brief The superscript z (Unicode U+1DBB)
- * @note This is used to check if a superscript is converted correctly, do not use this in the program.
- */
-#define SUP_Z "\u1DBB"
-/**
- * @brief The superscript magic number (8304)
- * @note This is used to check if a superscript is converted correctly, do not use this in the program.
- */
-#define SUP_MAGIC_NUMBER 8304
+    // Superscripts
+    /**
+     * @brief The superscript 0 (Unicode U+2070)
+     * @note This is used to check if a superscript is converted correctly, do not use this in the program.
+     */
+    constexpr std::string_view SUP_0 = "\u2070";
+    /**
+     * @brief The superscript z (Unicode U+1DBB)
+     * @note This is used to check if a superscript is converted correctly, do not use this in the program.
+     */
+    constexpr std::string_view SUP_Z = "\u1DBB";
+    /**
+     * @brief The superscript magic number (8304)
+     * @note This is used to check if a superscript is converted correctly, do not use this in the program.
+     */
+    constexpr int SUP_MAGIC_NUMBER = 8304;
 
     /**
      * @brief Create a superscript string from a normal string.
@@ -274,12 +270,12 @@ namespace steppable::prettyPrint::printers
     /**
      * @brief Pretty print a fraction.
      *
-     * @param numerator The numerator.
-     * @param denominator The denominator.
+     * @param top The numerator.
+     * @param bottom The denominator.
      * @param inLine Whether to print in a single line.
      * @return The pretty printed fraction.
      */
-    std::string ppFraction(const std::string& numerator, const std::string& denominator, const bool inLine = false);
+    std::string ppFraction(const std::string& top, const std::string& bottom, bool inLine = false);
 
     /**
      * @brief Pretty print a base expression, (aka, subscript).

--- a/include/symbols.hpp
+++ b/include/symbols.hpp
@@ -116,8 +116,7 @@ namespace steppable::prettyPrint
          * @brief Writes a string to the buffer.
          *
          * @param s The string to write.
-         * @param dLine The change in line.
-         * @param dCol The change in column.
+         * @param pos The position to write to.
          * @param updatePos Whether to update the current position.
          */
         void write(const std::string& s, const Position& pos, bool updatePos = false);
@@ -290,7 +289,7 @@ namespace steppable::prettyPrint::printers
      * @brief Pretty print a power expression, (aka, superscript).
      *
      * @param base The base.
-     * @param exponent The exponent.
+     * @param superscript The exponent.
      * @return The pretty printed power expression.
      */
     std::string ppSuperscript(const std::string& base, const std::string& superscript);

--- a/include/symbols.hpp
+++ b/include/symbols.hpp
@@ -51,7 +51,7 @@ namespace steppable::prettyPrint
     {
         long long x = 0;
         long long y = 0;
-    } __attribute__((aligned(16)));
+    };
 
     // // Not currently in use.
     // enum PrintingAlignment

--- a/include/testing.hpp
+++ b/include/testing.hpp
@@ -35,6 +35,7 @@
 using namespace std::literals;
 
 /// @brief This macro defines the main function and initializes the Utf8CodePage object, and prepares the error counter.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define TEST_START()                                         \
     int main()                                               \
     {                                                        \
@@ -46,6 +47,7 @@ using namespace std::literals;
         int errors = 0;
 
 /// @brief This macro defines a test section with the given name.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define SECTION(...)                                                                            \
     {                                                                                           \
         const std::string& nameSection = #__VA_ARGS__;                                          \
@@ -55,6 +57,7 @@ using namespace std::literals;
         auto _ = TestCase(nameSection);
 
 /// @brief This macro ends a test section and prints the time taken to execute the section.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define SECTION_END()                                                                                            \
     auto end = std::chrono::high_resolution_clock::now();                                                        \
     auto duration =                                                                                              \
@@ -68,6 +71,7 @@ using namespace std::literals;
     }
 
 /// @brief This macro ends the main function and prints the number of errors encountered.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define TEST_END()                                                                          \
     if (errors)                                                                             \
         error("TEST_END", "Not all tests passed. There are %i errors."s, errors);           \
@@ -97,7 +101,7 @@ namespace steppable::testing
         std::string_view testCaseName;
 
     public:
-        int errorCount = 0;
+        int errorCount = 0; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
 
         /**
          * @brief Constructs a new TestCase object with the given name.

--- a/include/testing.hpp
+++ b/include/testing.hpp
@@ -37,6 +37,7 @@ using namespace std::literals;
 /// @brief This macro defines the main function and initializes the Utf8CodePage object, and prepares the error counter.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define TEST_START()                                         \
+    /* NOLINTNEXTLINE(bugprone-exception-escape) */          \
     int main()                                               \
     {                                                        \
         using namespace steppable::__internals::stringUtils; \

--- a/include/types/result.hpp
+++ b/include/types/result.hpp
@@ -35,7 +35,7 @@ namespace steppable::types
     /**
      * @brief The status of the calculation.
      */
-    enum Status
+    enum class Status
     {
         CALCULATED_SIMPLIFIED,
         CALCULATED_UNSIMPLIFIED,
@@ -43,13 +43,29 @@ namespace steppable::types
     };
 
     /**
-     * @brief The result of a calculation.
+     * @brief The status of a boolean calculation.
      */
-    class Result
+    enum class StatusBool
+    {
+        CALCULATED_SIMPLIFIED_YES,
+        CALCULATED_SIMPLIFIED_NO,
+        CALCULATED_UNSIMPLIFIED_YES,
+        CALCULATED_UNSIMPLIFIED_NO,
+        MATH_ERROR
+    };
+
+    /**
+     * @brief A base class for a result of a calculation. You should use the `Result` and `ResultBool` aliases instead
+     * of this class, which has the `Status` and `StatusBool` enums as the status type respectively.
+     *
+     * @tparam StatusType The type of the status of the calculation.
+     */
+    template<typename StatusType>
+    class ResultBase
     {
     private:
         /// @brief Whether the calculation is done.
-        Status done;
+        StatusType done;
 
         /// @brief The inputs to the calculation.
         std::vector<std::string> inputs;
@@ -58,7 +74,7 @@ namespace steppable::types
         std::string out;
 
     public:
-        Result() = delete;
+        ResultBase() = delete;
 
         /**
          * @brief Constructs a new result object.
@@ -67,12 +83,24 @@ namespace steppable::types
          * @param[in] _out The output of the calculation.
          * @param[in] _done A flag indicating how the calculation is done.
          */
-        Result(const std::vector<std::string>& _inputs, std::string _out, Status _done) :
+        ResultBase(const std::vector<std::string>& _inputs, std::string _out, StatusType _done) :
             done(_done), inputs(_inputs), out(std::move(_out))
         {
         }
 
         /// @brief Gets how the calculation is done.
-        Status getStatus() { return done; }
+        StatusType getStatus() const { return done; }
+
+        /// @brief Gets the output of the calculation.
+        std::string getOutput() const { return out; }
+
+        /// @brief Gets the inputs to the calculation.
+        std::vector<std::string> getInputs() const { return inputs; }
     };
+
+    /// @brief An alias for a result of a calculation. This represents a calculation with a `Status` status.
+    using Result = ResultBase<Status>;
+
+    /// @brief An alias for a result of a boolean calculation.
+    using ResultBool = ResultBase<StatusBool>;
 } // namespace steppable::types

--- a/include/types/result.hpp
+++ b/include/types/result.hpp
@@ -20,30 +20,59 @@
  * SOFTWARE.                                                                                      *
  **************************************************************************************************/
 
-#include "colors.hpp"
-#include "fn/basicArithm.hpp"
-#include "output.hpp"
-#include "testing.hpp"
-#include "util.hpp"
+#pragma once
 
-#include <iomanip>
-#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
-TEST_START()
-SECTION(Root with a sqare number)
-using namespace steppable::__internals::arithmetic;
-_.assertIsEqual(root("4", "2", 0), "2");
-SECTION_END()
+/**
+ * @namespace steppable::types
+ * @brief The namespace containing types used in the steppable calculator.
+ */
+namespace steppable::types
+{
+    /**
+     * @brief The status of the calculation.
+     */
+    enum Status
+    {
+        CALCULATED_SIMPLIFIED,
+        CALCULATED_UNSIMPLIFIED,
+        MATH_ERROR
+    };
 
-SECTION(Root with a decimal index)
-using namespace steppable::__internals::arithmetic;
-_.assertIsEqual(root("4", "0.5", 0), "16");
-SECTION_END()
+    /**
+     * @brief The result of a calculation.
+     */
+    class Result
+    {
+    private:
+        /// @brief Whether the calculation is done.
+        Status done;
 
-SECTION(Surds)
-using namespace steppable::__internals::arithmetic;
-auto surd = rootSurd("27", "2");
-_.assertIsEqual(surd.multiplier, "3");
-_.assertIsEqual(surd.radicand, "3");
-SECTION_END()
-TEST_END()
+        /// @brief The inputs to the calculation.
+        std::vector<std::string> inputs;
+
+        /// @brief The output of the calculation.
+        std::string out;
+
+    public:
+        Result() = delete;
+
+        /**
+         * @brief Constructs a new result object.
+         *
+         * @param[in] _inputs The inputs to the calculation.
+         * @param[in] _out The output of the calculation.
+         * @param[in] _done A flag indicating how the calculation is done.
+         */
+        Result(const std::vector<std::string>& _inputs, std::string _out, Status _done) :
+            done(_done), inputs(_inputs), out(std::move(_out))
+        {
+        }
+
+        /// @brief Gets how the calculation is done.
+        Status getStatus() { return done; }
+    };
+} // namespace steppable::types

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -39,13 +39,16 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <clocale>
 #include <iomanip>
 #include <iostream>
-#include <locale.h>
-#include <locale>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#ifndef ALIGN64
+    #define ALIGN64 __attribute__((aligned(64)))
+#endif
 
 #ifndef TIC
     /**
@@ -79,7 +82,7 @@ namespace steppable::__internals::utils
     #if (_MSC_VER || __MINGW32__ || __MSVCRT__)
         #define MS_STDLIB_BUGS 1
     #else
-        #define MS_STDLIB_BUGS 0
+        #define MS_STDLIB_BUGS 0 // NOLINT(cppcoreguidelines-macro-usage)
     #endif
 #endif
 
@@ -508,4 +511,11 @@ namespace steppable::__internals::stringUtils
      * @see Utf8CodePage
      */
     std::string unicodeToUtf8(int unicode);
+
+    /**
+     * @brief Gets the duplicates in a vector of strings.
+     * @param[in] vector The vector of strings to check for duplicates.
+     * @return A vector of strings containing the duplicates.
+     */
+    std::vector<std::string> duplicates(const std::vector<std::string>& vector);
 } // namespace steppable::__internals::stringUtils

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -46,10 +46,6 @@
 #include <string>
 #include <vector>
 
-#ifndef ALIGN64
-    #define ALIGN64 __attribute__((aligned(64)))
-#endif
-
 #ifndef TIC
     /**
      * @brief Starts a timer for profiling code execution time.

--- a/lib/bindings.cpp
+++ b/lib/bindings.cpp
@@ -34,7 +34,7 @@ namespace nb = nanobind;
 using namespace steppable::__internals::arithmetic;
 using namespace nb::literals;
 
-NB_MODULE(steppyble, mod)
+NB_MODULE(steppyble, mod) // NOLINT
 {
     auto internals = mod.def_submodule("_internals", "Internal functions.");
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,56 +20,59 @@
 #  SOFTWARE.                                                                                        #
 #####################################################################################################
 
-add_library(util STATIC argParse.cpp colors.cpp logging.cpp symbols.cpp testing.cpp util.cpp)
-set_target_properties(util PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ADD_LIBRARY(util STATIC argParse.cpp colors.cpp logging.cpp symbols.cpp testing.cpp util.cpp)
+SET_TARGET_PROPERTIES(util PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-add_library(steppable STATIC number.cpp fraction.cpp)
-set_target_properties(steppable PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ADD_LIBRARY(steppable STATIC number.cpp fraction.cpp)
+SET_TARGET_PROPERTIES(steppable PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-set(CALCULATOR_FILES)
+SET(CALCULATOR_FILES)
 
-function(COPY_TO_BIN TARGET_NAME)
-    if (DEFINED STP_BUILD_COMPONENT_EXECUTABLE)
-        if (WINDOWS)
-            add_custom_command(TARGET ${TARGET_NAME}
-                    POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET_NAME}>
-                    ${CMAKE_CURRENT_BINARY_DIR}/../bin/${TARGET_NAME}.exe)
-        else ()
-            add_custom_command(TARGET ${TARGET_NAME}
-                    POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET_NAME}>
-                    ${CMAKE_CURRENT_BINARY_DIR}/../bin/${TARGET_NAME})
-        endif ()
-    endif ()
-endfunction()
+FUNCTION(COPY_TO_BIN TARGET_NAME)
+    IF(DEFINED STP_BUILD_COMPONENT_EXECUTABLE)
+        IF(WINDOWS)
+            ADD_CUSTOM_COMMAND(
+                TARGET ${TARGET_NAME}
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET_NAME}>
+                        ${CMAKE_CURRENT_BINARY_DIR}/../bin/${TARGET_NAME}.exe
+            )
+        ELSE()
+            ADD_CUSTOM_COMMAND(
+                TARGET ${TARGET_NAME}
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET_NAME}>
+                        ${CMAKE_CURRENT_BINARY_DIR}/../bin/${TARGET_NAME}
+            )
+        ENDIF()
+    ENDIF()
+ENDFUNCTION()
 
-foreach (COMPONENT IN LISTS COMPONENTS)
-    message(TRACE "Adding component: ${COMPONENT}: ${COMPONENT}/${COMPONENT}.cpp, ${COMPONENT}/${COMPONENT}Report.cpp")
+FOREACH(COMPONENT IN LISTS COMPONENTS)
+    MESSAGE(TRACE "Adding component: ${COMPONENT}: ${COMPONENT}/${COMPONENT}.cpp, ${COMPONENT}/${COMPONENT}Report.cpp")
 
     # No longer offering executables for each component automatically.
+    IF(DEFINED STP_BUILD_COMPONENT_EXECUTABLE)
+        ADD_EXECUTABLE(${COMPONENT} ${COMPONENT}/${COMPONENT}.cpp ${COMPONENT}/${COMPONENT}Report.cpp)
+        TARGET_INCLUDE_DIRECTORIES(${COMPONENT} PRIVATE ${STP_BASE_DIRECTORY}/include/)
+        TARGET_LINK_LIBRARIES(${COMPONENT} PRIVATE calc)
+    ENDIF()
 
-    if (DEFINED STP_BUILD_COMPONENT_EXECUTABLE)
-        add_executable(${COMPONENT} ${COMPONENT}/${COMPONENT}.cpp ${COMPONENT}/${COMPONENT}Report.cpp)
-        target_include_directories(${COMPONENT} PRIVATE ${STP_BASE_DIRECTORY}/include/)
-        target_link_libraries(${COMPONENT} PRIVATE calc)
-    endif ()
-
-    list(APPEND CALCULATOR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COMPONENT}/${COMPONENT}.cpp
-                                 ${CMAKE_CURRENT_SOURCE_DIR}/${COMPONENT}/${COMPONENT}Report.cpp)
+    LIST(APPEND CALCULATOR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COMPONENT}/${COMPONENT}.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/${COMPONENT}/${COMPONENT}Report.cpp
+    )
 
     COPY_TO_BIN(${COMPONENT})
-endforeach ()
+ENDFOREACH()
 
-add_library(calc STATIC ${CALCULATOR_FILES} fraction.cpp rounding.cpp number.cpp)
-set_target_properties(calc PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ADD_LIBRARY(calc STATIC ${CALCULATOR_FILES} fraction.cpp rounding.cpp factors.cpp number.cpp)
+SET_TARGET_PROPERTIES(calc PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(steppable PRIVATE ${STP_BASE_DIRECTORY}/include/)
-target_include_directories(calc PRIVATE ${STP_BASE_DIRECTORY}/include/)
-target_include_directories(util PRIVATE ${STP_BASE_DIRECTORY}/include/)
+TARGET_INCLUDE_DIRECTORIES(steppable PRIVATE ${STP_BASE_DIRECTORY}/include/)
+TARGET_INCLUDE_DIRECTORIES(calc PRIVATE ${STP_BASE_DIRECTORY}/include/)
+TARGET_INCLUDE_DIRECTORIES(util PRIVATE ${STP_BASE_DIRECTORY}/include/)
 
-target_link_libraries(steppable PRIVATE util)
-target_link_libraries(calc PRIVATE steppable)
-target_compile_definitions(calc PRIVATE NO_MAIN)
-target_compile_definitions(steppable PRIVATE NO_MAIN)
-
+TARGET_LINK_LIBRARIES(steppable PRIVATE util)
+TARGET_LINK_LIBRARIES(calc PRIVATE steppable)
+TARGET_COMPILE_DEFINITIONS(calc PRIVATE NO_MAIN)
+TARGET_COMPILE_DEFINITIONS(steppable PRIVATE NO_MAIN)

--- a/src/abs/abs.cpp
+++ b/src/abs/abs.cpp
@@ -30,7 +30,6 @@
 
 #include "absReport.hpp"
 #include "argParse.hpp"
-#include "output.hpp"
 #include "util.hpp"
 
 #include <fn/basicArithm.hpp>

--- a/src/abs/absReport.cpp
+++ b/src/abs/absReport.cpp
@@ -37,6 +37,7 @@
 #include <util.hpp>
 
 using namespace steppable::__internals::numUtils;
+using namespace steppable::__internals::symbols;
 
 std::string reportAbs(const std::string_view& number, int steps = 2)
 {
@@ -47,12 +48,12 @@ std::string reportAbs(const std::string_view& number, int steps = 2)
         if (number[0] == '-')
         {
             ss << "Since " << number << " is negative, abs(" << number << ") = -(" << number << ")\n";
-            ss << THEREFORE " The absolute value of " << number << " is " << standardizeNumber(number.substr(1));
+            ss << THEREFORE << " The absolute value of " << number << " is " << standardizeNumber(number.substr(1));
         }
         else
         {
             ss << "Since " << number << " is positive, abs(" << number << ") = " << number << '\n';
-            ss << THEREFORE " The absolute value of " << number << " is " << standardizeNumber(number);
+            ss << THEREFORE << " The absolute value of " << number << " is " << standardizeNumber(number);
         }
     }
     else if (steps == 1)

--- a/src/add/add.cpp
+++ b/src/add/add.cpp
@@ -41,6 +41,7 @@
 using namespace steppable::__internals::numUtils;
 using namespace steppable::__internals::utils;
 using namespace steppable::__internals::arithmetic;
+using namespace steppable::__internals::symbols;
 
 namespace steppable::__internals::arithmetic
 {
@@ -55,8 +56,8 @@ namespace steppable::__internals::arithmetic
             std::stringstream ss;
             if (steps == 2)
             {
-                ss << BECAUSE " a = 0, the result is " << b << '\n';
-                ss << THEREFORE " " << a << " + " << b << " = " << b;
+                ss << BECAUSE << " a = 0, the result is " << b << '\n';
+                ss << THEREFORE << " " << a << " + " << b << " = " << b;
             }
             else if (steps == 1)
                 ss << a << " + " << b << " = " << b;
@@ -71,8 +72,8 @@ namespace steppable::__internals::arithmetic
             std::stringstream ss;
             if (steps == 2)
             {
-                ss << BECAUSE " b = 0, the result is " << a << '\n';
-                ss << THEREFORE " " << a << " + " << b << " = " << a;
+                ss << BECAUSE << " b = 0, the result is " << a << '\n';
+                ss << THEREFORE << " " << a << " + " << b << " = " << a;
             }
             else if (steps == 1)
                 ss << a << " + " << b << " = " << a;
@@ -84,7 +85,8 @@ namespace steppable::__internals::arithmetic
         auto [splitNumberArray, aIsNegative, bIsNegative] = splitNumber(a, b, true, true, properlyFormat);
         auto [aInteger, aDecimal, bInteger, bDecimal] = splitNumberArray;
         bool resultIsNegative = false;
-        const bool aIsDecimal = not isZeroString(aDecimal), bIsDecimal = not isZeroString(bDecimal);
+        const bool aIsDecimal = not isZeroString(aDecimal);
+        const bool bIsDecimal = not isZeroString(bDecimal);
 
         if (negative)
             resultIsNegative = true;
@@ -107,15 +109,18 @@ namespace steppable::__internals::arithmetic
             return subtract(a, b.substr(1), steps);
         }
 
-        auto aStr = aInteger + aDecimal, bStr = bInteger + bDecimal;
+        auto aStr = aInteger + aDecimal;
+        auto bStr = bInteger + bDecimal;
         std::ranges::reverse(aStr);
         std::ranges::reverse(bStr);
 
         std::vector sumDigits(aStr.length() + 1, 0);
         std::vector carries(aStr.length() + 1, false);
+
         for (size_t index = 0; index < aStr.length(); index++)
         {
-            int aDigit = aStr[index] - '0', bDigit = bStr[index] - '0';
+            int aDigit = aStr[index] - '0';
+            int bDigit = bStr[index] - '0';
             if (aStr[index] == ' ')
                 aDigit = 0;
             if (bStr[index] == ' ')

--- a/src/add/addReport.cpp
+++ b/src/add/addReport.cpp
@@ -114,7 +114,7 @@ std::string reportAdd(const std::string& aInteger,
         if (c == -1)
             outStr += ".";
         else
-            outStr += std::string(1, c + '0');
+            outStr += std::string(1, static_cast<char>(c + '0'));
 
     if (properlyFormat)
         ss << standardizeNumber(outStr);

--- a/src/add/addReport.cpp
+++ b/src/add/addReport.cpp
@@ -54,20 +54,22 @@ std::string reportAdd(const std::string& aInteger,
 {
     std::stringstream ss;
 
-    const bool aIsDecimal = not isZeroString(aDecimal), bIsDecimal = not isZeroString(bDecimal);
-    std::string aOut = aInteger, bOut = bInteger;
+    const bool aIsDecimal = not isZeroString(aDecimal);
+    const bool bIsDecimal = not isZeroString(bDecimal);
+    std::string aOut = aInteger;
+    std::string bOut = bInteger;
     if (aIsDecimal)
         aOut += '.' + aDecimal;
-    else if (not steps)
+    else if (steps == 0)
         ; // Don't use the spaced formatting
     if (bIsDecimal)
         bOut += '.' + bDecimal;
-    else if (not steps)
+    else if (steps == 0)
         ; // Don't use the spaced formatting
 
-    if (aIsDecimal and not bIsDecimal and steps)
+    if (aIsDecimal and not bIsDecimal and (steps != 0))
         bOut += std::string(aDecimal.length() + 1, ' ');
-    if (bIsDecimal and not aIsDecimal and steps)
+    if (bIsDecimal and not aIsDecimal and (steps != 0))
         aOut += std::string(bDecimal.length() + 1, ' ');
 
     if (steps == 2)
@@ -95,12 +97,13 @@ std::string reportAdd(const std::string& aInteger,
         if (sumDigits.size() <= aOut.length())
             ss << "   ";
         ss << "   ";
+
         for (const int outputChar : sumDigits)
             if (outputChar == -1)
                 ss << ".  ";
             else
                 ss << outputChar << "  "; // Two spaces
-        ss << '\n' << THEREFORE " ";
+        ss << '\n' << THEREFORE << " ";
     }
 
     if (steps >= 1)

--- a/src/argParse.cpp
+++ b/src/argParse.cpp
@@ -135,14 +135,15 @@ namespace steppable::__internals::utils
         return switches[name];
     }
 
-    ProgramArgs::ProgramArgs(const int _argc, const char** _argv)
+    ProgramArgs::ProgramArgs(const int _argc, const char** _argv) : argc(_argc - 1)
     {
-        argc = _argc - 1;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         programName = _argv[0]; // Call this program whatever the user calls it
         PosArgs pos;
 
         // Copy the arguments into a vector
         for (int i = 0; i <= argc; i++)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             argv.emplace_back(_argv[i]);
         argv.erase(argv.begin());
     }

--- a/src/baseConvert/baseConvert.cpp
+++ b/src/baseConvert/baseConvert.cpp
@@ -36,7 +36,6 @@
 #include "symbols.hpp"
 #include "util.hpp"
 
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -52,8 +51,8 @@ namespace steppable::prettyPrint::printers
     std::string ppSubscript(const std::string& base, const std::string& subscript)
     {
         auto subscriptWidth = prettyPrint::getStringWidth(subscript);
-        auto width = prettyPrint::getStringWidth(base) + subscriptWidth + 1,
-             height = prettyPrint::getStringHeight(base) + 1; // +1 for the superscript
+        auto width = prettyPrint::getStringWidth(base) + subscriptWidth + 1;
+        auto height = prettyPrint::getStringHeight(base) + 1; // +1 for the superscript
 
         prettyPrint::ConsoleOutput output(height, width);
         prettyPrint::Position pos{ static_cast<long long>(width - subscriptWidth - 1), 1 };

--- a/src/baseConvert/baseConvertReport.cpp
+++ b/src/baseConvert/baseConvertReport.cpp
@@ -33,15 +33,15 @@
 #include "baseConvertReport.hpp"
 
 #include "symbols.hpp"
-#include "util.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
 using namespace std::string_literals;
-using namespace steppable::__internals::stringUtils;
+using namespace steppable::__internals::symbols;
 
 std::string reportBaseConvertStep(const std::string& _number,
                                   const std::string& _base,
@@ -49,7 +49,7 @@ std::string reportBaseConvertStep(const std::string& _number,
                                   const std::string& _remainder)
 {
     std::stringstream ss;
-    ss << _number << " " DIVIDED_BY " " << _base << " = " << _quotient << " ... " << _remainder;
+    ss << _number << " " << DIVIDED_BY << " " << _base << " = " << _quotient << " ... " << _remainder;
     return ss.str();
 }
 
@@ -65,8 +65,10 @@ std::string reportBaseConvert(const std::string& _number,
     else if (steps == 1)
         ss << _number << steppable::__internals::symbols::makeSubscript("10") << " = ";
     // Output the result in reverse order
-    for (auto it = _result.rbegin(); it != _result.rend(); ++it)
-        ss << *it;
+    auto result = _result;
+    std::reverse(result.begin(), result.end());
+    for (const auto& item : result)
+        ss << item;
     if (steps == 1)
         ss << steppable::__internals::symbols::makeSubscript(_base);
     return ss.str();

--- a/src/baseConvert/baseConvertReport.hpp
+++ b/src/baseConvert/baseConvertReport.hpp
@@ -33,7 +33,6 @@
 #pragma once
 
 #include <string>
-#include <string_view>
 #include <vector>
 
 /**
@@ -63,4 +62,4 @@ std::string reportBaseConvertStep(const std::string& _number,
 std::string reportBaseConvert(const std::string& _number,
                               const std::string& _base,
                               const std::vector<std::string>& _result,
-                              const int steps);
+                              int steps);

--- a/src/comparison/comparison.cpp
+++ b/src/comparison/comparison.cpp
@@ -37,6 +37,7 @@
 #include <string_view>
 
 using namespace steppable::__internals::numUtils;
+using namespace steppable::__internals::symbols;
 using namespace steppable::__internals::utils;
 using namespace steppable::__internals::arithmetic;
 
@@ -46,9 +47,14 @@ namespace steppable::__internals::arithmetic
     {
         if (standardizeNumber(_a) == standardizeNumber(_b))
         {
+            std::stringstream ss;
             if (steps == 2)
-                return BECAUSE " " + static_cast<std::string>(_a) + " is identical to " + static_cast<std::string>(_b) +
-                       ", " THEREFORE " a = b";
+            {
+                ss << BECAUSE << " " << static_cast<std::string>(_a) << " is identical to "
+                   << static_cast<std::string>(_b);
+                ss << ", " << THEREFORE << " a = b";
+                return ss.str();
+            }
             if (steps == 1)
                 return static_cast<std::string>(_a) + " = " + static_cast<std::string>(_b);
             return "2";
@@ -62,7 +68,8 @@ namespace steppable::__internals::arithmetic
         if (bIntegerReal.empty())
             bIntegerReal = "0";
 
-        auto a = aIntegerReal + "." + aDecimalReal, b = bIntegerReal + "." + bDecimalReal;
+        auto a = aIntegerReal + "." + aDecimalReal;
+        auto b = bIntegerReal + "." + bDecimalReal;
         if (
             // a is longer than b and is of different polarities
             aIntegerReal.length() != bIntegerReal.length() and aIsNegative == bIsNegative)
@@ -91,7 +98,7 @@ namespace steppable::__internals::arithmetic
 
         for (long i = 0; static_cast<size_t>(i) < a.length(); i++)
         {
-            if (a[i] == b[i] or not isdigit(a[i]) or not isdigit(b[i]))
+            if (a[i] == b[i] or (isdigit(a[i]) == 0) or (isdigit(b[i]) == 0))
                 continue; // Negative sign, decimal point or equals
             if (a[i] > b[i] and not bothNegative)
                 return reportComparisonByDigit(a, b, i, true, false, steps);

--- a/src/comparison/comparisonReport.cpp
+++ b/src/comparison/comparisonReport.cpp
@@ -70,7 +70,7 @@ std::string reportComparisonAtInteger(const std::string_view& a,
 
 std::string reportComparisonByPolarity(const std::string_view& a,
                                        const std::string_view& b,
-                                       const bool bigger,
+                                       const bool greater,
                                        const int steps)
 {
     std::stringstream ss;
@@ -78,7 +78,7 @@ std::string reportComparisonByPolarity(const std::string_view& a,
     if (steps == 2)
     {
         ss << "Comparing the polarities of a and b" << '\n';
-        if (bigger)
+        if (greater)
         {
             ss << BECAUSE << " " << a << " is positive and " << b << " is negative" << '\n';
             ss << THEREFORE << " " << a << " is greater than " << b;
@@ -90,9 +90,9 @@ std::string reportComparisonByPolarity(const std::string_view& a,
         }
     }
     else if (steps == 1)
-        ss << a << (bigger ? " > " : " < ") << b;
+        ss << a << (greater ? " > " : " < ") << b;
     else
-        ss << (bigger ? '1' : '0');
+        ss << (greater ? '1' : '0');
 
     return ss.str();
 }
@@ -100,7 +100,7 @@ std::string reportComparisonByPolarity(const std::string_view& a,
 std::string reportComparisonByDigit(const std::string_view& a,
                                     const std::string_view& b,
                                     const size_t _digit,
-                                    const bool bigger,
+                                    const bool greater,
                                     const bool bothNegative,
                                     const int steps)
 {
@@ -111,7 +111,7 @@ std::string reportComparisonByDigit(const std::string_view& a,
         ss << "a = " << a << '\n';
         ss << "b = " << b << '\n';
 
-        if (bigger)
+        if (greater)
         {
             ss << std::string(digit + 4, ' ') << "^~~~~ " << BECAUSE << " At digit " << digit + 1 << ", " << a[digit]
                << " is greater than " << b[digit] << '\n';
@@ -125,9 +125,9 @@ std::string reportComparisonByDigit(const std::string_view& a,
         }
     }
     else if (steps == 1)
-        ss << a << (bigger ? " > " : " < ") << b;
+        ss << a << (greater ? " > " : " < ") << b;
     else
-        ss << (bigger ? '1' : '0');
+        ss << (greater ? '1' : '0');
 
     return ss.str();
 }

--- a/src/comparison/comparisonReport.cpp
+++ b/src/comparison/comparisonReport.cpp
@@ -37,6 +37,8 @@
 #include <sstream>
 #include <string_view>
 
+using namespace steppable::__internals::symbols;
+
 std::string reportComparisonAtInteger(const std::string_view& a,
                                       const std::string_view& b,
                                       const bool bigger,
@@ -50,12 +52,12 @@ std::string reportComparisonAtInteger(const std::string_view& a,
         if (bigger)
         {
             ss << BECAUSE << " The integer part of " << a << " is bigger than the integer part of " << b << '\n';
-            ss << THEREFORE " " << a << " is greater than " << b;
+            ss << THEREFORE << " " << a << " is greater than " << b;
         }
         else
         {
-            ss << BECAUSE " The integer part of " << b << " is bigger than the integer part of " << a << '\n';
-            ss << THEREFORE " " << a << " is less than " << b;
+            ss << BECAUSE << " The integer part of " << b << " is bigger than the integer part of " << a << '\n';
+            ss << THEREFORE << " " << a << " is less than " << b;
         }
     }
     else if (steps == 1)
@@ -79,12 +81,12 @@ std::string reportComparisonByPolarity(const std::string_view& a,
         if (bigger)
         {
             ss << BECAUSE << " " << a << " is positive and " << b << " is negative" << '\n';
-            ss << THEREFORE " " << a << " is greater than " << b;
+            ss << THEREFORE << " " << a << " is greater than " << b;
         }
         else
         {
             ss << BECAUSE << " " << a << " is negative and " << b << " is positive" << '\n';
-            ss << THEREFORE " " << a << " is less than " << b;
+            ss << THEREFORE << " " << a << " is less than " << b;
         }
     }
     else if (steps == 1)
@@ -111,15 +113,15 @@ std::string reportComparisonByDigit(const std::string_view& a,
 
         if (bigger)
         {
-            ss << std::string(digit + 4, ' ') << "^~~~~ " BECAUSE " At digit " << digit + 1 << ", " << a[digit]
+            ss << std::string(digit + 4, ' ') << "^~~~~ " << BECAUSE << " At digit " << digit + 1 << ", " << a[digit]
                << " is greater than " << b[digit] << '\n';
-            ss << THEREFORE " " << a << " is greater than " << b;
+            ss << THEREFORE << " " << a << " is greater than " << b;
         }
         else
         {
-            ss << std::string(digit + 4, ' ') << "^~~~~ " BECAUSE " At digit " << digit + 1 << ", " << a[digit]
+            ss << std::string(digit + 4, ' ') << "^~~~~ " << BECAUSE << " At digit " << digit + 1 << ", " << a[digit]
                << " is less than " << b[digit] << '\n';
-            ss << THEREFORE " " << a << " is less than " << b;
+            ss << THEREFORE << " " << a << " is less than " << b;
         }
     }
     else if (steps == 1)

--- a/src/comparison/comparisonReport.hpp
+++ b/src/comparison/comparisonReport.hpp
@@ -81,6 +81,6 @@ std::string reportComparisonByPolarity(const std::string_view& a,
 std::string reportComparisonByDigit(const std::string_view& a,
                                     const std::string_view& b,
                                     size_t digit,
-                                    bool bigger,
+                                    bool greater,
                                     bool bothNegative,
                                     int steps = 2);

--- a/src/decimalConvert/decimalConvert.cpp
+++ b/src/decimalConvert/decimalConvert.cpp
@@ -80,7 +80,6 @@ namespace steppable::__internals::arithmetic
         for (auto iterator = inputString.begin(); iterator < inputString.end(); ++iterator)
         {
             auto index = iterator - inputString.begin();
-            auto currentIndex = std::to_string(index);
             auto digit = toNumber(inputString[index]);
 
             if (compare(digit, baseString, 0) != "0")

--- a/src/decimalConvert/decimalConvert.cpp
+++ b/src/decimalConvert/decimalConvert.cpp
@@ -50,7 +50,7 @@ namespace steppable::__internals::arithmetic
      */
     std::string toNumber(const char _input)
     {
-        const char input = toupper(_input);
+        const char input = static_cast<char>(toupper(_input));
         if ('0' <= input and input <= '9')
             return { input };
         // If letters are used in counting, it should be like this:
@@ -70,7 +70,8 @@ namespace steppable::__internals::arithmetic
             return "";
         }
 
-        std::string converted = "0", inputString = static_cast<std::string>(_inputString);
+        std::string converted = "0";
+        std::string inputString = static_cast<std::string>(_inputString);
         std::ranges::reverse(inputString);
 
         auto maxWidth = power(baseString, std::to_string(_inputString.length()), 0).length();
@@ -88,8 +89,8 @@ namespace steppable::__internals::arithmetic
                       "The digit "s + digit + " is larger than the base " + static_cast<std::string>(baseString));
                 return "";
             }
-            auto placeValue = power(baseString, std::to_string(index), 0),
-                 convertedDigit = multiply(placeValue, digit, 0);
+            auto placeValue = power(baseString, std::to_string(index), 0);
+            auto convertedDigit = multiply(placeValue, digit, 0);
             converted = add(converted, convertedDigit, 0);
 
             if (steps == 2)
@@ -114,16 +115,17 @@ int main(int _argc, const char* _argv[])
 
     int steps = program.getKeywordArgument("steps");
     bool profile = program.getSwitch("profile");
-    const auto &inputString = program.getPosArg(0), baseString = program.getPosArg(1);
+    const auto& inputString = program.getPosArg(0);
+    const auto baseString = program.getPosArg(1);
 
     if (profile)
     {
         TIC(Decimal Conversion)
-        std::cout << "Decimal Conversion :\n" << decimalConvert(inputString, baseString, steps) << std::endl;
+        std::cout << "Decimal Conversion :\n" << decimalConvert(inputString, baseString, steps) << '\n';
         TOC()
     }
     else
-        std::cout << decimalConvert(inputString, baseString, steps) << std::endl;
+        std::cout << decimalConvert(inputString, baseString, steps) << '\n';
 }
 
 #endif

--- a/src/decimalConvert/decimalConvertReport.cpp
+++ b/src/decimalConvert/decimalConvertReport.cpp
@@ -39,9 +39,9 @@ std::string reportDecimalConvertStep(const std::string_view& baseString,
 {
     std::stringstream ss;
 
-    ss << digit << " " MULTIPLY " ";
-    ss << baseString << makeSuperscript(powerIndex + '0');
-    ss << " = " << std::setw(maxWidth) << convertedDigit << std::setw(0);
+    ss << digit << " " << MULTIPLY << " ";
+    ss << baseString << makeSuperscript(static_cast<char>(powerIndex + '0'));
+    ss << " = " << std::setw(static_cast<int>(maxWidth)) << convertedDigit << std::setw(0);
     return ss.str();
 }
 
@@ -55,7 +55,7 @@ std::string reportDecimalConvert(const std::string_view& inputString,
 
     std::stringstream ss;
     if (steps == 2)
-        ss << THEREFORE " ";
+        ss << THEREFORE << " ";
     ss << inputString << makeSubscript(static_cast<std::string>(baseString)) << " = ";
     ss << convertedString << makeSubscript("10");
     return ss.str();

--- a/src/decimalConvert/decimalConvertReport.hpp
+++ b/src/decimalConvert/decimalConvertReport.hpp
@@ -26,11 +26,11 @@
 
 std::string reportDecimalConvertStep(const std::string_view& baseString,
                                      const std::string_view& digit,
-                                     const size_t powerIndex,
+                                     size_t powerIndex,
                                      const std::string_view& convertedDigit,
-                                     const size_t maxWidth);
+                                     size_t maxWidth);
 
 std::string reportDecimalConvert(const std::string_view& inputString,
                                  const std::string_view& baseString,
                                  const std::string_view& convertedString,
-                                 const int steps = 2);
+                                 int steps = 2);

--- a/src/division/division.cpp
+++ b/src/division/division.cpp
@@ -31,7 +31,6 @@
 #include "argParse.hpp"
 #include "divisionReport.hpp"
 #include "fn/basicArithm.hpp"
-#include "logging.hpp"
 #include "output.hpp"
 #include "rounding.hpp"
 #include "util.hpp"
@@ -50,7 +49,6 @@ using namespace steppable::__internals::arithmetic;
 
 namespace steppable::__internals::arithmetic
 {
-
     QuotientRemainder getQuotientRemainder(const auto& _currentRemainder, const auto& divisor)
     {
         auto currentRemainder = removeLeadingZeros(_currentRemainder);
@@ -66,7 +64,8 @@ namespace steppable::__internals::arithmetic
             currentRemainder = subtract(currentRemainder, divisor, 0);
         }
 
-        const auto &quotient = std::to_string(out), remainder = currentRemainder;
+        const auto& quotient = std::to_string(out);
+        const auto remainder = currentRemainder;
         return { quotient, remainder };
     }
 
@@ -79,9 +78,11 @@ namespace steppable::__internals::arithmetic
      */
     long long determineResultScale(const std::string& _number, const std::string& _divisor)
     {
-        std::string number = _number, divisor = _divisor;
+        std::string number = _number;
+        std::string divisor = _divisor;
         long long numberScale = determineScale(number);
-        long long divisorScale = determineScale(divisor), diffScale = std::abs(numberScale - divisorScale);
+        long long divisorScale = determineScale(divisor);
+        long long diffScale = std::abs(numberScale - divisorScale);
 
         // Step 1: Make divisor the same scale as number
         // Method: If divisorScale > numberScale -> Scale up number.
@@ -139,9 +140,9 @@ namespace steppable::__internals::arithmetic
         {
             std::stringstream ss;
             if (steps == 2)
-                ss << "Since " << _number << " is equal to " << _divisor << ", " THEREFORE " the result is 1";
+                ss << "Since " << _number << " is equal to " << _divisor << ", " << THEREFORE << " the result is 1";
             else if (steps == 1)
-                ss << _number << " " DIVIDED_BY " " << _divisor << " = 1";
+                ss << _number << " " << DIVIDED_BY << " " << _divisor << " = 1";
             else
                 ss << "1";
             return ss.str();
@@ -151,10 +152,13 @@ namespace steppable::__internals::arithmetic
             return roundOff(static_cast<std::string>(_number), _decimals);
 
         auto splitNumberResult = splitNumber(_number, _divisor, false, true);
-        bool numberIsNegative = splitNumberResult.aIsNegative, divisorIsNegative = splitNumberResult.bIsNegative;
+        bool numberIsNegative = splitNumberResult.aIsNegative;
+        bool divisorIsNegative = splitNumberResult.bIsNegative;
         auto [numberInteger, numberDecimal, divisorInteger, divisorDecimal] = splitNumberResult.splitNumberArray;
-        auto numberIntegerOrig = numberInteger, divisorIntegerOrig = divisorInteger, numberDecimalOrig = numberDecimal,
-             divisorDecimalOrig = divisorDecimal;
+        auto numberIntegerOrig = numberInteger;
+        auto divisorIntegerOrig = divisorInteger;
+        auto numberDecimalOrig = numberDecimal;
+        auto divisorDecimalOrig = divisorDecimal;
         auto decimals = _decimals;
 
         // Here, we determine the polarity of the result.
@@ -195,7 +199,9 @@ namespace steppable::__internals::arithmetic
             number += '0';
 
         unsigned long long idx = 0;
-        std::string remainder(1, number[0]), lastRemainder, header = makeWider(divisor) + ") " + makeWider(number);
+        std::string remainder(1, number[0]);
+        std::string lastRemainder;
+        std::string header = makeWider(divisor) + ") " + makeWider(number);
         tempFormattedAns << header << '\n';
         auto width = static_cast<int>(header.length());
 
@@ -234,8 +240,8 @@ namespace steppable::__internals::arithmetic
         // Solution  : Round to the nearest decimal place
         else if (numberDecimals >= decimals and numberIntegers > 0)
         {
-            auto beforeDecimal = quotient.substr(0, numberIntegers),
-                 afterDecimal = quotient.substr(numberIntegers, numberDecimals);
+            auto beforeDecimal = quotient.substr(0, numberIntegers);
+            auto afterDecimal = quotient.substr(numberIntegers, numberDecimals);
             if (beforeDecimal.empty())
                 beforeDecimal = "0";
             if (not afterDecimal.empty())
@@ -271,8 +277,9 @@ namespace steppable::__internals::arithmetic
         const auto& divisionResult = divide(number, divisor, 0);
         const auto& splitNumberResult = splitNumber(divisionResult, "0", false, false, true, true).splitNumberArray;
 
-        const auto &quotient = splitNumberResult[0], nearestResult = multiply(divisor, quotient, 0),
-                   &remainder = removeLeadingZeros(subtract(number, nearestResult, 0));
+        const auto& quotient = splitNumberResult[0];
+        const auto nearestResult = multiply(divisor, quotient, 0);
+        const auto& remainder = removeLeadingZeros(subtract(number, nearestResult, 0));
 
         return { quotient, remainder };
     }
@@ -282,7 +289,8 @@ namespace steppable::__internals::arithmetic
         // Sign for GCD does not matter.
         // https://proofwiki.org/wiki/GCD_for_Negative_Integers
         auto splitNumberResult = splitNumber(_a, _b, false, false, true, false).splitNumberArray;
-        auto a = splitNumberResult[0] + splitNumberResult[1], b = splitNumberResult[2] + splitNumberResult[3];
+        auto a = splitNumberResult[0] + splitNumberResult[1];
+        auto b = splitNumberResult[2] + splitNumberResult[3];
 
         // Ensure that a is greater than or equal to b
         if (b > a)
@@ -321,7 +329,7 @@ int main(const int _argc, const char* _argv[])
 
     if (steps == 5)
     {
-        std::cout << getGCD(aStr, bStr) << std::endl;
+        std::cout << getGCD(aStr, bStr) << '\n';
         return 0;
     }
     if (profile)

--- a/src/division/divisionReport.cpp
+++ b/src/division/divisionReport.cpp
@@ -32,7 +32,6 @@
 #include "divisionReport.hpp"
 
 #include "fn/basicArithm.hpp"
-#include "internals.hpp"
 #include "util.hpp"
 
 #include <sstream>
@@ -41,6 +40,7 @@
 
 using namespace std::literals;
 using namespace steppable::__internals::stringUtils;
+using namespace steppable::__internals::symbols;
 using namespace steppable::__internals::arithmetic;
 
 std::string reportDivision(std::stringstream& tempFormattedAns,
@@ -64,7 +64,7 @@ std::string reportDivision(std::stringstream& tempFormattedAns,
         formattedAns << std::string(width - divisor.length() * 2, '_') << '\n';
         formattedAns << tempFormattedAns.rdbuf();
 
-        formattedAns << THEREFORE " ";
+        formattedAns << THEREFORE << " ";
     }
 
     if (steps >= 1)
@@ -99,7 +99,7 @@ std::string reportDivisionStep(const std::string_view& temp,
 
     const auto outputWidth = index == 0 ? (divisor.length() - 1) * 3 :
                                           3 * (divisor.length() + index + normalWidth - lastRemainder.length() - 2);
-    for (auto i : splitResult)
+    for (const auto& i : splitResult)
         ss << std::string(outputWidth, ' ') << i << '\n';
 
     return ss.str();

--- a/src/division/divisionReport.hpp
+++ b/src/division/divisionReport.hpp
@@ -56,9 +56,9 @@ std::string reportDivision(std::stringstream& tempFormattedAns,
                            const std::string_view& divisor,
                            const std::string_view& _divisor,
                            const std::string_view& _number,
-                           const int steps,
-                           const int width,
-                           const bool resultIsNegative);
+                           int steps,
+                           int width,
+                           bool resultIsNegative);
 
 /**
  * @brief Reports a division step.

--- a/src/factors.cpp
+++ b/src/factors.cpp
@@ -23,7 +23,6 @@
 #include "factors.hpp"
 
 #include "fn/basicArithm.hpp"
-#include "util.hpp"
 
 #include <vector>
 
@@ -52,7 +51,18 @@ namespace steppable::__internals::numUtils
         return factors;
     }
 
-    std::string getRootFactor(const std::string& _number, const std::string& base) { return "1"; }
+    std::string getRootFactor(const std::string& _number, const std::string& base)
+    {
+        auto factors = getFactors(_number);
+        // Reverse the factors
+        std::reverse(factors.begin(), factors.end());
+        // Get the largest root factor
+        for (const auto& factor : factors)
+            if (isRoot(factor, base))
+                return factor;
+        // The number has no root factors
+        return "1";
+    }
 
     std::string getGreatestRootNum(const std::string& _number, const std::string& base)
     {
@@ -64,5 +74,12 @@ namespace steppable::__internals::numUtils
     {
         auto factors = getFactors(_number);
         return factors.size() == 2; // Only 1 and the number itself are factors ==> prime!
+    }
+
+    bool isRoot(const std::string& _number, const std::string& base)
+    {
+        auto iRoot = rootIntPart(_number, base);
+        auto rootNum = power(iRoot, base, 0);
+        return compare(rootNum, _number, 0) == "2";
     }
 } // namespace steppable::__internals::numUtils

--- a/src/factors.cpp
+++ b/src/factors.cpp
@@ -20,32 +20,49 @@
  * SOFTWARE.                                                                                      *
  **************************************************************************************************/
 
-#include "colors.hpp"
+#include "factors.hpp"
+
 #include "fn/basicArithm.hpp"
-#include "output.hpp"
-#include "testing.hpp"
 #include "util.hpp"
 
-#include <iomanip>
-#include <iostream>
-
-TEST_START()
+#include <vector>
 
 using namespace steppable::__internals::arithmetic;
 
-SECTION(Decimal Convert without letters)
-const std::string &a = "46432231133131";
-const std::string &b = "8";
-const auto& result = decimalConvert(a, b, 0);
+namespace steppable::__internals::numUtils
+{
+    std::vector<std::string> getFactors(const std::string& _number)
+    {
+        std::vector<std::string> factors;
+        // If the number is negative, add a negative sign to the factors
+        if (_number[0] == '-')
+            factors.emplace_back("-1");
+        // Get the absolute value of the number
+        auto number = abs(_number, 0);
+        // Get the factors of the number
+        loop(number, [&](const std::string& factor) {
+            if (factor != "0")
+            {
+                auto quotientRemainder = divideWithQuotient(number, factor);
+                if (quotientRemainder.remainder == "0")
+                    factors.push_back(factor);
+            }
+        });
+        factors.push_back(number);
+        return factors;
+    }
 
-_.assertIsEqual(result, "2649229669977");
-SECTION_END()
+    std::string getRootFactor(const std::string& _number, const std::string& base) { return "1"; }
 
-SECTION(Decimal Convert)
-const std::string &a = "88a";
-const std::string &b = "16";
-const auto& result = decimalConvert(a, b, 0);
+    std::string getGreatestRootNum(const std::string& _number, const std::string& base)
+    {
+        auto integralPart = rootIntPart(_number, base);
+        return power(integralPart, base, 0);
+    }
 
-_.assertIsEqual(result, "2186");
-SECTION_END()
-TEST_END()
+    bool isPrime(const std::string& _number)
+    {
+        auto factors = getFactors(_number);
+        return factors.size() == 2; // Only 1 and the number itself are factors ==> prime!
+    }
+} // namespace steppable::__internals::numUtils

--- a/src/factors.cpp
+++ b/src/factors.cpp
@@ -23,11 +23,13 @@
 #include "factors.hpp"
 
 #include "fn/basicArithm.hpp"
+#include "types/result.hpp"
 
 #include <algorithm>
 #include <vector>
 
 using namespace steppable::__internals::arithmetic;
+using namespace steppable::types;
 
 namespace steppable::__internals::numUtils
 {
@@ -52,17 +54,20 @@ namespace steppable::__internals::numUtils
         return factors;
     }
 
-    std::string getRootFactor(const std::string& _number, const std::string& base)
+    ResultBool getRootFactor(const std::string& _number, const std::string& base)
     {
         auto factors = getFactors(_number);
         // Reverse the factors
         std::reverse(factors.begin(), factors.end());
         // Get the largest root factor
         for (const auto& factor : factors)
-            if (isRoot(factor, base))
-                return factor;
+        {
+            auto rootResult = isRoot(factor, base);
+            if (rootResult.getStatus() == StatusBool::CALCULATED_SIMPLIFIED_YES)
+                return { { _number, base, rootResult.getOutput() }, factor, StatusBool::CALCULATED_SIMPLIFIED_YES };
+        }
         // The number has no root factors
-        return "1";
+        return { { _number, base }, "1", StatusBool::CALCULATED_SIMPLIFIED_YES };
     }
 
     std::string getGreatestRootNum(const std::string& _number, const std::string& base)
@@ -77,10 +82,12 @@ namespace steppable::__internals::numUtils
         return factors.size() == 2; // Only 1 and the number itself are factors ==> prime!
     }
 
-    bool isRoot(const std::string& _number, const std::string& base)
+    ResultBool isRoot(const std::string& _number, const std::string& base)
     {
         auto iRoot = rootIntPart(_number, base);
         auto rootNum = power(iRoot, base, 0);
-        return compare(rootNum, _number, 0) == "2";
+        if (compare(rootNum, _number, 0) == "2")
+            return { { _number, base }, iRoot, StatusBool::CALCULATED_SIMPLIFIED_YES };
+        return { { _number, base }, "1", StatusBool::CALCULATED_SIMPLIFIED_NO };
     }
 } // namespace steppable::__internals::numUtils

--- a/src/factors.cpp
+++ b/src/factors.cpp
@@ -24,6 +24,7 @@
 
 #include "fn/basicArithm.hpp"
 
+#include <algorithm>
 #include <vector>
 
 using namespace steppable::__internals::arithmetic;

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -54,21 +54,18 @@ namespace steppable::prettyPrint::printers
         if (inLine)
             return top + "/" + bottom;
         // Output in three lines, with top and bottom aligned to center.
-        auto topWidth = prettyPrint::getStringWidth(top), bottomWidth = prettyPrint::getStringWidth(bottom);
+        auto topWidth = prettyPrint::getStringWidth(top);
+        auto bottomWidth = prettyPrint::getStringWidth(bottom);
         auto width = std::max(topWidth, bottomWidth) + 2;
-        auto topSpacing = std::string((width - topWidth) / 2, ' '),
-             bottomSpacing = std::string((width - bottomWidth) / 2, ' ');
+        auto topSpacing = std::string((width - topWidth) / 2, ' ');
+        auto bottomSpacing = std::string((width - bottomWidth) / 2, ' ');
         return topSpacing + top + '\n' + std::string(width, '-') + '\n' + bottomSpacing + bottom;
     }
 } // namespace steppable::prettyPrint::printers
 
 namespace steppable
 {
-    Fraction::Fraction()
-    {
-        this->top = "1";
-        this->bottom = "1";
-    }
+    Fraction::Fraction() : top("1"), bottom("1") {}
 
     Fraction::Fraction(const std::string& top, const std::string& bottom)
     {
@@ -79,10 +76,9 @@ namespace steppable
         simplify();
     }
 
-    Fraction::Fraction(const Number& number)
+    Fraction::Fraction(const Number& number) : bottom("1")
     {
         this->top = number.present();
-        this->bottom = "1";
         simplify();
     }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -31,15 +31,12 @@
 namespace steppable::__internals::logging
 {
 #if DEBUG
-    Logger::Logger(const std::string& name, const std::string& filename, const Level level)
+    Logger::Logger(const std::string& name, const std::string& filename, const Level level) : level(level), name(name)
 #else
-    Logger::Logger(const std::string& name, const std::string& filename, const Level level)
+    Logger::Logger(const std::string& name, const std::string& filename, const Level level) : level(level), name(name)
 #endif
     {
         file.open(filename);
-        this->level = level;
-        this->name = name;
-
         info(name + " logger started");
     }
 

--- a/src/multiply/multiply.cpp
+++ b/src/multiply/multiply.cpp
@@ -48,7 +48,8 @@ namespace steppable::__internals::arithmetic
 {
     std::string multiply(const std::string_view& _a, const std::string_view& _b, const int steps)
     {
-        auto a = static_cast<std::string>(_a), b = static_cast<std::string>(_b);
+        auto a = static_cast<std::string>(_a);
+        auto b = static_cast<std::string>(_b);
         std::stringstream out;
         if (isZeroString(a) or isZeroString(b))
         {
@@ -78,22 +79,24 @@ namespace steppable::__internals::arithmetic
         {
             if (steps == 2)
                 out << "Since " << a << " is a power of 10, we can move the decimal places to obtain the result.\n";
-            out << moveDecimalPlaces(b, a.length() - 1);
+            out << moveDecimalPlaces(b, static_cast<long long>(a.length() - 1));
             return out.str();
         }
         if (isPowerOfTen(b))
         {
             if (steps == 2)
                 out << "Since " << b << " is a power of 10, we can move the decimal places to obtain the result.\n";
-            out << moveDecimalPlaces(a, b.length() - 1);
+            out << moveDecimalPlaces(a, static_cast<long long>(b.length() - 1));
             return out.str();
         }
 
         const auto& [splitNumberArray, aIsNegative, bIsNegative] = splitNumber(a, b, false, false);
         bool resultIsNegative = false;
         const auto& [aInteger, aDecimal, bInteger, bDecimal] = splitNumberArray;
-        const std::string &aStr = aInteger + aDecimal, bStr = bInteger + bDecimal;
-        std::vector<std::vector<int>> prodDigits, carries;
+        const std::string& aStr = aInteger + aDecimal;
+        const std::string bStr = bInteger + bDecimal;
+        std::vector<std::vector<int>> prodDigits;
+        std::vector<std::vector<int>> carries;
 
         if (aIsNegative and bIsNegative)
             resultIsNegative = false; // NOLINT(bugprone-branch-clone)
@@ -105,10 +108,10 @@ namespace steppable::__internals::arithmetic
         for (size_t indexB = 0; indexB < bStr.length(); indexB++)
         {
             const int bDigit = static_cast<int>(bStr[indexB]) - '0';
-            std::vector<int> currentProdDigits(aStr.length() + bStr.length() + 1, 0),
-                currentCarries(aStr.length() + bStr.length() + 1, 0);
+            std::vector<int> currentProdDigits(aStr.length() + bStr.length() + 1, 0);
+            std::vector<int> currentCarries(aStr.length() + bStr.length() + 1, 0);
             if (bDigit == 0)
-                goto skip;
+                goto skip; // NOLINT(cppcoreguidelines-avoid-goto)
             for (long long indexA = static_cast<long long>(aStr.length()) - 1; indexA != -1; indexA--)
             {
                 const int aDigit = aStr[indexA] - '0';
@@ -141,7 +144,8 @@ namespace steppable::__internals::arithmetic
         }
 
         // Add the vectors digit-wise together
-        std::vector<int> finalProdDigits(prodDigits[0].size(), 0), finalProdCarries(prodDigits[0].size(), 0);
+        std::vector<int> finalProdDigits(prodDigits[0].size(), 0);
+        std::vector<int> finalProdCarries(prodDigits[0].size(), 0);
         for (long long indexDigit = static_cast<long long>(finalProdDigits.size()) - 1; indexDigit != -1; indexDigit--)
         {
             int sum = finalProdCarries[indexDigit];

--- a/src/multiply/multiply.cpp
+++ b/src/multiply/multiply.cpp
@@ -50,6 +50,9 @@ namespace steppable::__internals::arithmetic
     {
         auto a = static_cast<std::string>(_a);
         auto b = static_cast<std::string>(_b);
+        const auto& [splitNumberArray, aIsNegative, bIsNegative] = splitNumber(a, b, false, false);
+        bool resultIsNegative = false;
+        const auto& [aInteger, aDecimal, bInteger, bDecimal] = splitNumberArray;
         std::stringstream out;
         if (isZeroString(a) or isZeroString(b))
         {
@@ -79,20 +82,17 @@ namespace steppable::__internals::arithmetic
         {
             if (steps == 2)
                 out << "Since " << a << " is a power of 10, we can move the decimal places to obtain the result.\n";
-            out << moveDecimalPlaces(b, static_cast<long long>(a.length() - 1));
+            out << moveDecimalPlaces(b, static_cast<long long>(aInteger.length() - 1));
             return out.str();
         }
         if (isPowerOfTen(b))
         {
             if (steps == 2)
                 out << "Since " << b << " is a power of 10, we can move the decimal places to obtain the result.\n";
-            out << moveDecimalPlaces(a, static_cast<long long>(b.length() - 1));
+            out << moveDecimalPlaces(a, static_cast<long long>(bInteger.length() - 1));
             return out.str();
         }
 
-        const auto& [splitNumberArray, aIsNegative, bIsNegative] = splitNumber(a, b, false, false);
-        bool resultIsNegative = false;
-        const auto& [aInteger, aDecimal, bInteger, bDecimal] = splitNumberArray;
         const std::string& aStr = aInteger + aDecimal;
         const std::string bStr = bInteger + bDecimal;
         std::vector<std::vector<int>> prodDigits;

--- a/src/multiply/multiplyReport.cpp
+++ b/src/multiply/multiplyReport.cpp
@@ -62,8 +62,8 @@ std::string reportMultiply(const std::string& a,
     if (steps == 2)
     {
         const long long outputWidth = static_cast<long long>(prodDigitsOut[0].size()) * 3 - 2;
-        ss << std::right << std::setw(outputWidth + 3) << makeWider(aStr) << '\n';
-        ss << MULTIPLY << std::right << std::setw(outputWidth + 2) << makeWider(bStr) << '\n';
+        ss << std::right << std::setw(static_cast<int>(outputWidth + 3)) << makeWider(aStr) << '\n';
+        ss << MULTIPLY << std::right << std::setw(static_cast<int>(outputWidth + 2)) << makeWider(bStr) << '\n';
         ss << std::string(outputWidth + 6, '_') << '\n';
 
         for (size_t indexProdDigits = 0; indexProdDigits < prodDigitsOut.size(); indexProdDigits++)
@@ -93,7 +93,7 @@ std::string reportMultiply(const std::string& a,
             ss << '\n';
             ss << std::string(outputWidth + 6, '_') << '\n' << "   ";
             for (const int i : finalProdCarries)
-                if (i)
+                if (i != 0)
                     ss << makeSubscript(i + '0') << "  ";
                 else
                     ss << "   ";
@@ -102,10 +102,10 @@ std::string reportMultiply(const std::string& a,
             for (const int i : finalProdDigits)
                 ss << i << "  ";
         }
-        ss << "\n" THEREFORE " ";
+        ss << "\n" << THEREFORE << " ";
     }
     if (steps >= 1)
-        ss << a << " " MULTIPLY " " << b << " = ";
+        ss << a << " " << MULTIPLY << " " << b << " = ";
     if (resultIsNegative)
         ss << '-';
     const auto vector = removeLeadingZeros(finalProdDigits);
@@ -116,7 +116,7 @@ std::string reportMultiply(const std::string& a,
 
     // Add the decimal point.
     auto places = aDecimal.length() + bDecimal.length();
-    out = moveDecimalPlaces(out, -places);
+    out = moveDecimalPlaces(out, -static_cast<long long>(places));
 
     ss << standardizeNumber(out);
     return ss.str();

--- a/src/number.cpp
+++ b/src/number.cpp
@@ -42,13 +42,10 @@ namespace steppable
 {
     using namespace steppable::__internals::arithmetic;
 
-    Number::Number() { value = "0"; }
+    Number::Number() : prec(8), value("0") {}
 
-    Number::Number(const std::string& value, size_t prec, RoundingMode mode)
+    Number::Number(std::string value, size_t prec, RoundingMode mode) : value(std::move(value)), prec(prec), mode(mode)
     {
-        this->value = value;
-        this->prec = prec;
-        this->mode = mode;
     }
 
     Number Number::operator+(const Number& rhs) const { return add(value, rhs.value, 0); }
@@ -59,7 +56,7 @@ namespace steppable
 
     Number Number::operator/(const Number& rhs) const
     {
-        size_t usePrec;
+        size_t usePrec = 0;
         if (mode == USE_MAXIMUM_PREC)
             usePrec = std::max(prec, rhs.prec);
         else if (mode == USE_MINIMUM_PREC)
@@ -75,7 +72,7 @@ namespace steppable
             usePrec = 0;
             output::warning("Invalid precision specified");
         }
-        return divide(value, rhs.value, 0, usePrec);
+        return divide(value, rhs.value, 0, static_cast<int>(usePrec));
     }
 
     Number Number::operator%(const Number& rhs) const { return divideWithQuotient(value, rhs.value).remainder; }
@@ -118,47 +115,17 @@ namespace steppable
         return *this;
     }
 
-    bool Number::operator==(const Number& rhs) const
-    {
-        if (compare(value, rhs.value, 0) == "2")
-            return true;
-        return false;
-    }
+    bool Number::operator==(const Number& rhs) const { return compare(value, rhs.value, 0) == "2"; }
 
-    bool Number::operator!=(const Number& rhs) const
-    {
-        if (compare(value, rhs.value, 0) != "2")
-            return true;
-        return false;
-    }
+    bool Number::operator!=(const Number& rhs) const { return compare(value, rhs.value, 0) != "2"; }
 
-    bool Number::operator<(const Number& rhs) const
-    {
-        if (compare(value, rhs.value, 0) == "0")
-            return true;
-        return false;
-    }
+    bool Number::operator<(const Number& rhs) const { return compare(value, rhs.value, 0) == "0"; }
 
-    bool Number::operator>(const Number& rhs) const
-    {
-        if (compare(value, rhs.value, 0) == "1")
-            return true;
-        return false;
-    }
+    bool Number::operator>(const Number& rhs) const { return compare(value, rhs.value, 0) == "1"; }
 
-    bool Number::operator<=(const Number& rhs) const
-    {
-        if (compare(value, rhs.value, 0) != "1")
-            return true;
-        return false;
-    }
+    bool Number::operator<=(const Number& rhs) const { return compare(value, rhs.value, 0) != "1"; }
 
-    bool Number::operator>=(const Number& rhs) const
-    {
-        if (compare(value, rhs.value, 0) != "0")
-            return true;
-        return false;
-    }
+    bool Number::operator>=(const Number& rhs) const { return compare(value, rhs.value, 0) != "0"; }
 
     Number Number::operator++()
     {

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -42,8 +42,8 @@ namespace steppable::prettyPrint::printers
 {
     std::string ppSuperscript(const std::string& base, const std::string& superscript)
     {
-        auto width = prettyPrint::getStringWidth(base) + 1,
-             height = prettyPrint::getStringHeight(base) + 1; // +1 for the superscript
+        auto width = prettyPrint::getStringWidth(base) + 1;
+        auto height = prettyPrint::getStringHeight(base) + 1; // +1 for the superscript
 
         prettyPrint::ConsoleOutput output(height, width);
         prettyPrint::Position pos{ static_cast<long long>(width - 1), 0 };
@@ -57,7 +57,8 @@ namespace steppable::__internals::arithmetic
 {
     std::string power(const std::string_view _number, const std::string_view& _raiseTo, const int steps)
     {
-        std::string raiseTo = static_cast<std::string>(_raiseTo), number = static_cast<std::string>(_number);
+        std::string raiseTo = static_cast<std::string>(_raiseTo);
+        std::string number = static_cast<std::string>(_number);
 
         if (isDecimal(raiseTo))
         {
@@ -68,7 +69,8 @@ namespace steppable::__internals::arithmetic
             // 3. Take the root of the number to the denominator of the fraction.
             const auto& fraction = Fraction(raiseTo);
             const auto& [top, bottom] = fraction.asArray();
-            const auto &powerResult = power(_number, top, 0), rootResult = root(powerResult, bottom, 8, 0);
+            const auto& powerResult = power(_number, top, 0);
+            const auto rootResult = root(powerResult, bottom, 8, 0);
             return reportPowerRoot(number, raiseTo, fraction, rootResult, steps);
         }
 

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -70,7 +70,7 @@ namespace steppable::__internals::arithmetic
             const auto& fraction = Fraction(raiseTo);
             const auto& [top, bottom] = fraction.asArray();
             const auto& powerResult = power(_number, top, 0);
-            const auto rootResult = root(powerResult, bottom, 8, 0);
+            const auto rootResult = root(powerResult, bottom, 8);
             return reportPowerRoot(number, raiseTo, fraction, rootResult, steps);
         }
 

--- a/src/power/powerReport.cpp
+++ b/src/power/powerReport.cpp
@@ -77,7 +77,7 @@ std::string reportPower(const std::string_view _number,
 
     // Here, we attempt to give a quick answer, instead of doing pointless iterations.
     if (numberOrig == "1")
-        goto finish;
+        goto finish; // NOLINT(cppcoreguidelines-avoid-goto)
     if (numberOrig == "0")
     {
         if (steps == 2)
@@ -96,9 +96,9 @@ std::string reportPower(const std::string_view _number,
         if (steps == 2)
         {
             if (not negative)
-                ss << BECAUSE " " << multiply(number, numberOrig, 1) << '\n';
+                ss << BECAUSE << " " << multiply(number, numberOrig, 1) << '\n';
             else
-                ss << BECAUSE " " << divide("1", number, 1) << '\n';
+                ss << BECAUSE << " " << divide("1", number, 1) << '\n';
             if (negative)
                 currentPower = "-" + currentPower;
 
@@ -112,7 +112,7 @@ finish:
     if (negative)
     {
         if (steps == 2)
-            ss << BECAUSE " " << divide("1", number, 1) << '\n';
+            ss << BECAUSE << " " << divide("1", number, 1) << '\n';
         else if (steps == 1)
         {
             const auto& divisionResult = divide("1", number, 0);

--- a/src/power/powerReport.hpp
+++ b/src/power/powerReport.hpp
@@ -46,7 +46,7 @@ std::string reportPowerRoot(const std::string& _number,
                             const std::string& raiseTo,
                             const steppable::Fraction& fraction,
                             const std::string& result,
-                            const int steps);
+                            int steps);
 
 /**
  * @brief Reports a power operation.
@@ -58,8 +58,8 @@ std::string reportPowerRoot(const std::string& _number,
  *
  * @return The formatted power report.
  */
-std::string reportPower(const std::string_view _number,
+std::string reportPower(std::string_view _number,
                         const std::string_view& raiseTo,
-                        const size_t numberTrailingZeros,
-                        const bool negative,
-                        const int steps);
+                        size_t numberTrailingZeros,
+                        bool negative,
+                        int steps);

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -117,8 +117,8 @@ namespace steppable::__internals::arithmetic
     Surd rootSurd(const std::string& _number, const std::string& base)
     {
         auto largestRootFactor = numUtils::getRootFactor(_number, base);
-        auto radicand = roundDown(divide(_number, largestRootFactor, 0, 1));
-        auto multiplier = rootIntPart(largestRootFactor, base);
+        auto radicand = roundDown(divide(_number, largestRootFactor.getOutput(), 0, 1));
+        auto multiplier = largestRootFactor.getInputs()[2];
 
         return { radicand, multiplier };
     }

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -123,15 +123,15 @@ namespace steppable::__internals::arithmetic
         return { radicand, multiplier };
     }
 
-    std::string root(const std::string& _number, const std::string& base, const size_t _decimals, const int steps)
+    std::string _root(const std::string& _number, const std::string& base, const size_t _decimals)
     {
-        if (numUtils::isDecimal(base))
+        if (isDecimal(base))
         {
             const auto& fraction = Fraction(base);
             const auto& [top, bottom] = fraction.asArray();
             const auto& powerResult = power(_number, bottom, 0);
-            const auto rootResult = root(powerResult, top, _decimals, 0);
-            return reportRootPower(_number, base, fraction, rootResult, steps);
+            const auto rootResult = _root(powerResult, top, _decimals);
+            return reportRootPower(_number, base, fraction, rootResult, 0);
         }
 
         if (compare(base, "1", 0) == "2")
@@ -148,7 +148,6 @@ namespace steppable::__internals::arithmetic
 
         auto x = number;
         auto y = "0"s;
-        auto allowedError = "0." + std::string(decimals - 1, '0') + "1";
         size_t idx = 0;
         auto denominator = "1" + std::string(raisedTimes, '0');
 
@@ -168,6 +167,13 @@ namespace steppable::__internals::arithmetic
             idx++;
             // std::cout << "iteration: " << idx << " error: " << error << " test: " << test << "\n";
         }
+    }
+
+    std::string root(const std::string& _number, const std::string& base, const size_t _decimals)
+    {
+        auto result = rootSurd(_number, base);
+        auto rootResult = _root(result.radicand, base, _decimals);
+        return multiply(rootResult, result.multiplier, 0);
     }
 } // namespace steppable::__internals::arithmetic
 

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -32,6 +32,7 @@
 #include "fn/basicArithm.hpp"
 #include "fraction.hpp"
 #include "rootReport.hpp"
+#include "rounding.hpp"
 #include "symbols.hpp"
 #include "util.hpp"
 
@@ -56,12 +57,13 @@ namespace steppable::prettyPrint::printers
         //   /        2
         // \/ radicand
         auto indexWidth = prettyPrint::getStringWidth(index);
-        auto width = prettyPrint::getStringWidth(radicand) + indexWidth + 3,
-             height = prettyPrint::getStringHeight(radicand) + 1;
-        auto spacingWidth = std::max(height, indexWidth), firstLineSpacingWidth = spacingWidth - indexWidth;
+        auto width = prettyPrint::getStringWidth(radicand) + indexWidth + 3;
+        auto height = prettyPrint::getStringHeight(radicand) + 1;
+        auto spacingWidth = std::max(height, indexWidth);
+        auto firstLineSpacingWidth = spacingWidth - indexWidth;
         auto lines = split(radicand, '\n');
-        auto spacing = std::string(firstLineSpacingWidth, ' '),
-             topBar = std::string(prettyPrint::getStringWidth(radicand), '-');
+        auto spacing = std::string(firstLineSpacingWidth, ' ');
+        auto topBar = std::string(prettyPrint::getStringWidth(radicand), '-');
 
         prettyPrint::ConsoleOutput output(height, width);
         prettyPrint::Position pos;
@@ -70,7 +72,7 @@ namespace steppable::prettyPrint::printers
         {
             const auto& line = lines[i];
             pos.y++;
-            pos.x = spacingWidth - i - 1;
+            pos.x = static_cast<long long>(spacingWidth - i - 1);
             output.write('/' + line, pos, true);
         }
         output.write("\\/"s, { pos.x - 1, pos.y }, true);
@@ -81,13 +83,46 @@ namespace steppable::prettyPrint::printers
 
 namespace steppable::__internals::arithmetic
 {
+    std::string rootIntPart(const std::string& _number, const std::string& base)
+    {
+        if (compare(_number, "1", 0) == "0")
+            return "0"; // Integral part of root of decimals less than 1 always 0.
+        if (compare(_number, "1", 0) == "2")
+            return "1"; // Integral part of root of 1 is always 1.
+        if (compare(base, "1", 0) == "2")
+            return numUtils::roundDown(_number); // Root with index 1 returns the number itself.
+
+        auto number = numUtils::roundDown(_number);
+        auto x = number;
+        auto y = "0"s;
+        while (true)
+        {
+            auto newAvg = divide(subtract(x, y, 0), "2", 0, 2);
+            auto radicand = add(y, newAvg, 0);
+            auto test = power(radicand, base, 0);
+
+            if (compare(newAvg, "0", 0) == "2")
+                return numUtils::roundDown(numUtils::roundOff(radicand, 1));
+            if (compare(test, number, 0) == "1")
+                x = radicand;
+            else if (compare(test, number, 0) == "0")
+                y = radicand;
+        }
+    }
+
+    std::string rootSurd(const std::string& _number, const std::string& base)
+    {
+        auto closestRoot = rootIntPart(_number, base);
+    }
+
     std::string root(const std::string& _number, const std::string& base, const size_t _decimals, const int steps)
     {
         if (numUtils::isDecimal(base))
         {
             const auto& fraction = Fraction(base);
             const auto& [top, bottom] = fraction.asArray();
-            const auto &powerResult = power(_number, bottom, 0), rootResult = root(powerResult, top, _decimals, 0);
+            const auto& powerResult = power(_number, bottom, 0);
+            const auto rootResult = root(powerResult, top, _decimals, 0);
             return reportRootPower(_number, base, fraction, rootResult, steps);
         }
 
@@ -103,18 +138,20 @@ namespace steppable::__internals::arithmetic
             raisedTimes++;
         }
 
-        auto x = number, y = "0"s, allowedError = "0." + std::string(decimals - 1, '0') + "1";
+        auto x = number;
+        auto y = "0"s;
+        auto allowedError = "0." + std::string(decimals - 1, '0') + "1";
         size_t idx = 0;
         auto denominator = "1" + std::string(raisedTimes, '0');
 
         while (true)
         {
-            auto newAvg = divide(subtract(x, y, 0), "2", 0, decimals + 1);
+            auto newAvg = divide(subtract(x, y, 0), "2", 0, static_cast<int>(decimals) + 1);
             auto radicand = add(y, newAvg, 0);
             auto test = power(radicand, base, 0);
 
             if (compare(newAvg, "0", 0) == "2")
-                return numUtils::standardizeNumber(divide(radicand, denominator, 0, _decimals));
+                return numUtils::standardizeNumber(divide(radicand, denominator, 0, static_cast<int>(_decimals)));
             if (compare(test, number, 0) == "1")
                 x = radicand;
             else if (compare(test, number, 0) == "0")

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -28,7 +28,10 @@
  * @date 1st May 2024
  */
 
+#include "fn/root.hpp"
+
 #include "argParse.hpp"
+#include "factors.hpp"
 #include "fn/basicArithm.hpp"
 #include "fraction.hpp"
 #include "rootReport.hpp"
@@ -110,9 +113,13 @@ namespace steppable::__internals::arithmetic
         }
     }
 
-    std::string rootSurd(const std::string& _number, const std::string& base)
+    Surd rootSurd(const std::string& _number, const std::string& base)
     {
-        auto closestRoot = rootIntPart(_number, base);
+        auto largestRootFactor = numUtils::getRootFactor(_number, base);
+        auto radicand = divide(_number, largestRootFactor, 0, 1);
+        auto multiplier = rootIntPart(largestRootFactor, base);
+
+        return { radicand, multiplier };
     }
 
     std::string root(const std::string& _number, const std::string& base, const size_t _decimals, const int steps)

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -49,6 +49,7 @@
 using namespace steppable::__internals::arithmetic;
 using namespace steppable::__internals::utils;
 using namespace steppable::__internals::stringUtils;
+using namespace steppable::__internals::numUtils;
 using namespace std::literals;
 
 namespace steppable::prettyPrint::printers
@@ -116,7 +117,7 @@ namespace steppable::__internals::arithmetic
     Surd rootSurd(const std::string& _number, const std::string& base)
     {
         auto largestRootFactor = numUtils::getRootFactor(_number, base);
-        auto radicand = divide(_number, largestRootFactor, 0, 1);
+        auto radicand = roundDown(divide(_number, largestRootFactor, 0, 1));
         auto multiplier = rootIntPart(largestRootFactor, base);
 
         return { radicand, multiplier };

--- a/src/root/root.cpp
+++ b/src/root/root.cpp
@@ -178,6 +178,7 @@ namespace steppable::__internals::arithmetic
 } // namespace steppable::__internals::arithmetic
 
 #ifndef NO_MAIN
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main(const int _argc, const char* _argv[])
 {
     Utf8CodePage _;

--- a/src/root/rootReport.hpp
+++ b/src/root/rootReport.hpp
@@ -30,6 +30,6 @@ std::string reportRootPower(const std::string& _number,
                             const std::string& base,
                             const steppable::Fraction& fraction,
                             const std::string& rootResult,
-                            const int steps);
+                            int steps);
 
 std::string reportRoot();

--- a/src/rounding.cpp
+++ b/src/rounding.cpp
@@ -129,7 +129,7 @@ namespace steppable::__internals::numUtils
         if (places > 0)
         {
             for (size_t _ = 0; _ < repetitions; _++)
-                if (decimal.length() > 0)
+                if (not decimal.empty())
                 {
                     integer += decimal[0];
                     decimal.erase(decimal.cbegin());
@@ -141,7 +141,7 @@ namespace steppable::__internals::numUtils
         else if (places < 0)
         {
             for (size_t _ = 0; _ < repetitions; _++)
-                if (integer.length() > 0)
+                if (not integer.empty())
                 {
                     decimal = integer.back() + decimal; // NOLINT(performance-inefficient-string-concatenation)
                     integer.pop_back();

--- a/src/rounding.cpp
+++ b/src/rounding.cpp
@@ -29,6 +29,34 @@
 
 namespace steppable::__internals::numUtils
 {
+    std::string roundDown(const std::string& _number)
+    {
+        auto number = _number;
+        if (number.empty())
+            return "0";
+        if (number.find('.') == std::string::npos)
+            return number;
+        // Round down the number
+        auto splitNumberResult = splitNumber(number, "0", false, false, false, false).splitNumberArray;
+        return splitNumberResult[0]; // Return the integer part
+    }
+
+    std::string roundUp(const std::string& _number)
+    {
+        auto number = _number;
+        if (number.empty())
+            return "0";
+        if (number.find('.') == std::string::npos)
+            return number;
+        // Round up the number
+        auto splitNumberResult = splitNumber(number, "0", false, true, true, false).splitNumberArray;
+        auto integer = splitNumberResult[0];
+        auto decimal = splitNumberResult[1]; // Return the integer part
+        if (decimal.front() > '5')
+            integer = arithmetic::add(integer, "1", 0);
+        return integer;
+    }
+
     std::string roundOff(const std::string& _number, const size_t digits)
     {
         auto number = _number;
@@ -38,7 +66,8 @@ namespace steppable::__internals::numUtils
             return number;
         // Round off the number
         auto splitNumberResult = splitNumber(number, "0", true, true, false, false).splitNumberArray;
-        auto integer = splitNumberResult[0], decimal = splitNumberResult[1];
+        auto integer = splitNumberResult[0];
+        auto decimal = splitNumberResult[1];
 
         // Preserve one digit after the rounded digit
         decimal = decimal.substr(0, digits + 1);
@@ -85,14 +114,15 @@ namespace steppable::__internals::numUtils
     {
         auto number = _number;
         // No change
-        if (not places)
+        if (places == 0)
             return number;
 
         // Is the number an integer?
         if (isInteger(number))
             number += ".0";
         auto splitNumberResult = splitNumber(number, "0", false, false, true, false).splitNumberArray;
-        auto integer = splitNumberResult[0], decimal = splitNumberResult[1];
+        auto integer = splitNumberResult[0];
+        auto decimal = splitNumberResult[1];
         auto repetitions = std::abs(places);
 
         // Move decimal places to the right
@@ -113,11 +143,11 @@ namespace steppable::__internals::numUtils
             for (size_t _ = 0; _ < repetitions; _++)
                 if (integer.length() > 0)
                 {
-                    decimal = integer.back() + decimal;
+                    decimal = integer.back() + decimal; // NOLINT(performance-inefficient-string-concatenation)
                     integer.pop_back();
                 }
                 else
-                    decimal = '0' + decimal;
+                    decimal = '0' + decimal; // NOLINT(performance-inefficient-string-concatenation)
         }
 
         auto result = integer + "." + decimal;

--- a/src/subtract/subtract.cpp
+++ b/src/subtract/subtract.cpp
@@ -52,8 +52,9 @@ namespace steppable::__internals::arithmetic
     {
         auto [splitNumberArray, aIsNegative, bIsNegative] = splitNumber(a, b);
         auto [aInteger, aDecimal, bInteger, bDecimal] = splitNumberArray;
-        bool resultIsNegative;
-        const bool aIsDecimal = not isZeroString(aDecimal), bIsDecimal = not isZeroString(bDecimal);
+        bool resultIsNegative = false;
+        const bool aIsDecimal = not isZeroString(aDecimal);
+        const bool bIsDecimal = not isZeroString(bDecimal);
 
         // Here, we try to determine if the result is negative or not
         // Scenario 1: a is negative and b is positive
@@ -121,7 +122,8 @@ namespace steppable::__internals::arithmetic
             return "-" + subtractResult;
         }
 
-        std::string aStr = aInteger + aDecimal, bStr = bInteger + bDecimal;
+        std::string aStr = aInteger + aDecimal;
+        std::string bStr = bInteger + bDecimal;
         std::ranges::reverse(aStr);
         std::ranges::reverse(bStr);
 
@@ -131,7 +133,8 @@ namespace steppable::__internals::arithmetic
         std::ranges::for_each(borrows, [](int& c) { c -= '0'; });
         for (int index = 0; index < aStr.length(); index++)
         {
-            int aDigit = borrows[index], bDigit = bStr[index] - '0';
+            int aDigit = borrows[index];
+            int bDigit = bStr[index] - '0';
             if (aStr[index] == ' ')
                 aDigit = 0;
             if (bStr[index] == ' ')
@@ -196,7 +199,8 @@ int main(int _argc, const char* _argv[])
     program.parseArgs();
 
     int steps = program.getKeywordArgument("steps");
-    bool profile = program.getSwitch("profile"), noMinus = program.getSwitch("noMinus");
+    bool profile = program.getSwitch("profile");
+    bool noMinus = program.getSwitch("noMinus");
     const auto& aStr = program.getPosArg(0);
     const auto& bStr = program.getPosArg(1);
 

--- a/src/subtract/subtractReport.cpp
+++ b/src/subtract/subtractReport.cpp
@@ -57,20 +57,21 @@ std::string reportSubtract(const std::string& aInteger,
     std::stringstream ss;
     auto aStr = aInteger + '.' + aDecimal;
     auto diffDigits = _diffDigits;
-    if (diffDigits.front() == 0 and not steps)
+    if (diffDigits.front() == 0 and (steps == 0))
         diffDigits = removeLeadingZeros(diffDigits);
     else if (diffDigits.front() == 0)
         diffDigits = replaceLeadingZeros(diffDigits);
 
-    auto aOut = aInteger, bOut = bInteger;
+    auto aOut = aInteger;
+    auto bOut = bInteger;
     if (aIsDecimal)
         aOut += '.' + aDecimal;
     if (bIsDecimal)
         bOut += '.' + bDecimal;
 
-    if (aIsDecimal and not bIsDecimal and not steps)
+    if (aIsDecimal and not bIsDecimal and (steps == 0))
         bOut += std::string(aDecimal.length() + 1, ' ');
-    if (not aIsDecimal and bIsDecimal and not steps)
+    if (not aIsDecimal and bIsDecimal and (steps == 0))
         aOut += std::string(bDecimal.length() + 1, ' ');
 
     if (steps == 2)
@@ -105,7 +106,7 @@ std::string reportSubtract(const std::string& aInteger,
                 outputChar = ' ';
             ss << outputChar << "  "; // Two spaces
         }
-        ss << '\n' << THEREFORE " ";
+        ss << '\n' << THEREFORE << " ";
     }
 
     if (steps >= 1)

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -37,7 +37,7 @@ namespace steppable::prettyPrint
 {
     using namespace steppable::__internals::stringUtils;
 
-    ConsoleOutput::ConsoleOutput(long long height, long long width) : height(height), width(width)
+    ConsoleOutput::ConsoleOutput(size_t height, size_t width) : height(height), width(width)
     {
         buffer = std::vector<std::vector<char>>(height, std::vector<char>(width, ' '));
     }
@@ -63,11 +63,11 @@ namespace steppable::prettyPrint
         }
         if (dCol < 0)
         {
-            for (long long i = 0; i < buffer.size(); i++)
+            for (auto& i : buffer)
             {
-                std::vector<char> vector = buffer[i];
+                std::vector<char> vector = i;
                 vector.resize(vector.size() - dCol, ' ');
-                buffer[i] = vector;
+                i = vector;
             }
 
             curPos.x -= dCol;
@@ -124,6 +124,7 @@ namespace steppable::__internals::symbols
 {
     using namespace steppable::__internals::stringUtils;
 
+    // NOLINTNEXTLINE(cert-err58-cpp)
     const std::array<std::string, 10>& SUPERSCRIPTS = { "\u2070", "\u00b9", "\u00b2", "\u00b3", "\u2074",
                                                         "\u2075", "\u2076", "\u2077", "\u2078", "\u2079" };
 
@@ -141,8 +142,8 @@ namespace steppable::__internals::symbols
     {
         std::stringstream ss;
         for (const char c : normal)
-            if (isdigit(c))
-                ss << SUPERSCRIPTS[c - '0'];
+            if (isdigit(c) != 0)
+                ss << SUPERSCRIPTS.at(c - '0');
             else
                 ss << ABOVE_DOT;
         std::string string = ss.str();
@@ -154,7 +155,7 @@ namespace steppable::__internals::symbols
         if (normal == '-')
             return "\u207B";
 
-        return SUPERSCRIPTS[normal - '0'];
+        return SUPERSCRIPTS.at(normal - '0');
     }
 
     std::string makeSurd(const std::string& radicand)

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -74,13 +74,13 @@ namespace steppable::testing
 
     void TestCase::assertTrue(const bool value)
     {
-        const std::string& conditionName = vFormat("%i is True", value);
+        const std::string& conditionName = vFormat("%i is True", static_cast<int>(value));
         assert(value, conditionName);
     }
 
     void TestCase::assertFalse(const bool value)
     {
-        const std::string& conditionName = vFormat("%i is False", value);
+        const std::string& conditionName = vFormat("%i is False", static_cast<int>(value));
         assert(not value, conditionName);
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -242,6 +242,8 @@ namespace steppable::__internals::numUtils
         // figure. Scale = -(numberOfZeros + 1)
         // E.g.: 0.1 => 0 leading zeros => scale = -(0 + 1) = -1; 0.0325 => 1 leading zero => scale = -(1 + 1) = -2.
         auto newNumberDecimal = removeLeadingZeros(numberDecimal);
+
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions, cppcoreguidelines-narrowing-conversions)
         long long numberOfZeros = static_cast<long long>(numberDecimal.length()) - newNumberDecimal.length();
         return -(numberOfZeros + 1);
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -23,6 +23,7 @@
 #include "util.hpp"
 
 #include <cstddef>
+#include <map>
 
 #ifdef WINDOWS
     #undef min
@@ -41,7 +42,8 @@ namespace steppable::__internals::numUtils
     {
         if (s.empty())
             return false;
-        int decimalPointCount = 0, minusCount = 0;
+        int decimalPointCount = 0;
+        int minusCount = 0;
 
         for (const char c : s)
         {
@@ -57,7 +59,7 @@ namespace steppable::__internals::numUtils
                     return false;
                 minusCount++;
             }
-            else if (not isdigit(c))
+            else if (isdigit(c) == 0)
                 return false;
         }
         return true;
@@ -104,9 +106,11 @@ namespace steppable::__internals::numUtils
                                   bool properlyFormat,
                                   bool preserveNegative)
     {
-        bool aIsNegative = false, bIsNegative = false;
+        bool aIsNegative = false;
+        bool bIsNegative = false;
 
-        auto a = static_cast<std::string>(_a), b = static_cast<std::string>(_b);
+        auto a = static_cast<std::string>(_a);
+        auto b = static_cast<std::string>(_b);
         if (properlyFormat)
         {
             a = simplifyPolarity(_a), b = simplifyPolarity(_b);
@@ -125,9 +129,12 @@ namespace steppable::__internals::numUtils
             a = removeLeadingZeros(a);
             b = removeLeadingZeros(b);
         }
-        const std::vector<std::string> aParts = stringUtils::split(a, '.'), bParts = stringUtils::split(b, '.');
-        auto aInteger = static_cast<std::string>(aParts.front()), aDecimal = static_cast<std::string>(aParts.back()),
-             bInteger = static_cast<std::string>(bParts.front()), bDecimal = static_cast<std::string>(bParts.back());
+        const std::vector<std::string> aParts = stringUtils::split(a, '.');
+        const std::vector<std::string> bParts = stringUtils::split(b, '.');
+        auto aInteger = static_cast<std::string>(aParts.front());
+        auto aDecimal = static_cast<std::string>(aParts.back());
+        auto bInteger = static_cast<std::string>(bParts.front());
+        auto bDecimal = static_cast<std::string>(bParts.back());
         if (properlyFormat)
         {
             // If the numbers are integers, discard their decimal points
@@ -172,7 +179,8 @@ namespace steppable::__internals::numUtils
         if (const auto firstNonZero = std::ranges::find_if(out, [](const int num) { return num != 0; });
             out.begin() != firstNonZero && out.front() == 0)
         {
-            std::replace_if(out.begin(), firstNonZero, [](const int num) { return num == 0; }, -2);
+            std::replace_if(
+                out.begin(), firstNonZero, [](const int num) { return num == 0; }, -2);
         }
 
         return out;
@@ -223,7 +231,8 @@ namespace steppable::__internals::numUtils
     long long determineScale(const std::string_view& number)
     {
         auto splitNumberResult = splitNumber(number, "0", false, false).splitNumberArray;
-        auto numberInteger = splitNumberResult[0], numberDecimal = splitNumberResult[1];
+        auto numberInteger = splitNumberResult[0];
+        auto numberDecimal = splitNumberResult[1];
 
         // If there is an integer component, determine the scale of it
         if (not isZeroString(numberInteger))
@@ -241,9 +250,7 @@ namespace steppable::__internals::numUtils
     {
         auto splitNumberResult = splitNumber(number, "0", false, false, true).splitNumberArray;
         // If the decimal part is zero, it is an integer.
-        if (isZeroString(splitNumberResult[1]))
-            return true;
-        return false;
+        return isZeroString(splitNumberResult[1]);
     }
 
     bool isDecimal(const std::string& number) { return not isInteger(number); }
@@ -254,6 +261,8 @@ namespace steppable::__internals::numUtils
             return true; // 1 is a power of 10.
         if (number.front() != '1')
             return false; // The number must start with 1.
+
+        // NOLINTNEXTLINE(readability-use-anyofallof)
         for (const char c : number.substr(1, number.length()))
             if (c != '0' and c != '.')
                 return false; // The rest of the number must be zeros or decimal points.
@@ -282,8 +291,8 @@ namespace steppable::__internals::stringUtils
 
         for (unsigned p = 0; p < utf8_size; ++p)
         {
-            const auto bit_count = p ? 6 : 8 - utf8_size - (utf8_size == 1 ? 0 : 1),
-                       shift = p < utf8_size - 1 ? 6 * (utf8_size - p - 1) : 0;
+            const auto bit_count = p != 0U ? 6 : 8 - utf8_size - (utf8_size == 1 ? 0 : 1);
+            const auto shift = p < utf8_size - 1 ? 6 * (utf8_size - p - 1) : 0;
 
             for (size_t k = 0; k < bit_count; ++k)
                 unicode += (utf8_code[p] & 1 << k) << shift;
@@ -304,7 +313,8 @@ namespace steppable::__internals::stringUtils
         }
         if (unicode <= 0x7ff) // 7FF(16) = 2047(10)
         {
-            unsigned char c1 = 192, c2 = 128;
+            unsigned char c1 = 192;
+            unsigned char c2 = 128;
 
             for (int k = 0; k < 11; ++k)
                 if (k < 6)
@@ -319,7 +329,9 @@ namespace steppable::__internals::stringUtils
         }
         if (unicode <= 0xffff) // 0xFFFF(16) = 65535(10)
         {
-            unsigned char c1 = 224, c2 = 128, c3 = 128;
+            unsigned char c1 = 224;
+            unsigned char c2 = 128;
+            unsigned char c3 = 128;
 
             for (int k = 0; k < 16; ++k)
                 if (k < 6)
@@ -337,7 +349,10 @@ namespace steppable::__internals::stringUtils
         }
         if (unicode <= 0x1fffff) // 1 * 0xFFFFF(16) = 2097151(10)
         {
-            unsigned char c1 = 240, c2 = 128, c3 = 128, c4 = 128;
+            unsigned char c1 = 240;
+            unsigned char c2 = 128;
+            unsigned char c3 = 128;
+            unsigned char c4 = 128;
 
             for (int k = 0; k < 21; ++k)
                 if (k < 6)
@@ -372,9 +387,8 @@ namespace steppable::__internals::utils
         _setmode(_fileno(stdout), _O_WTEXT);
 #else
         // The correct locale name may vary by OS, e.g., "en_US.utf8".
-        constexpr char locale_name[] = "";
-        setlocale(LC_ALL, locale_name);
-        std::locale::global(std::locale(locale_name));
+        (void)setlocale(LC_ALL, ""); // NOLINT(concurrency-mt-unsafe)
+        std::locale::global(std::locale(""));
         std::wcin.imbue(std::locale());
         std::wcout.imbue(std::locale());
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,11 +20,11 @@
 #  SOFTWARE.                                                                                        #
 #####################################################################################################
 
-enable_testing()
+ENABLE_TESTING()
 
-foreach (ITEM IN LISTS TEST_TARGETS)
-    add_executable(${ITEM} ${ITEM}.cpp)
-    target_link_libraries(${ITEM} PRIVATE calc)
-    add_test(NAME ${ITEM} COMMAND ${CMAKE_BINARY_DIR}/tests/${ITEM})
-    message(TRACE "Added test case: ${ITEM}: ${ITEM}.cpp")
-endforeach ()
+FOREACH(ITEM IN LISTS TEST_TARGETS)
+    ADD_EXECUTABLE(${ITEM} ${ITEM}.cpp)
+    TARGET_LINK_LIBRARIES(${ITEM} PRIVATE calc)
+    ADD_TEST(NAME ${ITEM} COMMAND ${CMAKE_BINARY_DIR}/tests/${ITEM})
+    MESSAGE(TRACE "Added test case: ${ITEM}: ${ITEM}.cpp")
+ENDFOREACH()

--- a/tests/random_tests/random_test_base.py
+++ b/tests/random_tests/random_test_base.py
@@ -87,7 +87,7 @@ class RandomTest:
         random.seed(time.time())
         top_limit = random.randint(100, int(1e100))
 
-        for _ in range(self.times):
+        for i in range(self.times):
             number1 = random.randint(1000, top_limit) / random.randint(1000, top_limit)
             number2 = random.randint(1000, top_limit) / random.randint(1000, top_limit)
 
@@ -110,13 +110,13 @@ class RandomTest:
             output = float(output.decode("utf-8")[:-1])
 
             expression = self.expression.format(number1, number2)
-            python_output = None
             if self.rounding:
                 python_output = round(eval(expression), 2)
             else:
                 python_output = eval(expression)
             print(
-                f"== For {expression},\n-> Steppable gives {output} while Python gives {python_output}"
+                f"\033[K\033[A\rTest [{i + 1}/{self.times}|{(i + 1) / self.times * 100:2.1f}%] - ",
+                end=""
             )
 
             diff = abs(python_output - output)
@@ -133,7 +133,6 @@ class RandomTest:
                 print(red() + f"PROBLEMATIC SCALE for {expression}" + reset())
             else:
                 print(green() + f"PASSED" + reset())
-            print()
 
         self.summary()
 

--- a/tests/testAdd.cpp
+++ b/tests/testAdd.cpp
@@ -34,7 +34,8 @@ TEST_START()
 using namespace steppable::__internals::arithmetic;
 
 SECTION(Addition with multiple digits of different length)
-const std::string &a = "6453.55", &b = "54329.334";
+const std::string& a = "6453.55";
+const std::string& b = "54329.334";
 const auto& addResult1 = add(a, b, 0);
 const auto& addResult2 = add(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(addResult1, "60782.884");
@@ -42,7 +43,8 @@ _.assertIsEqual(addResult1, addResult2);
 SECTION_END()
 
 SECTION(Addition with multiple digits of equal length)
-const std::string &a = "65943.595", &b = "54329.334";
+const std::string& a = "65943.595";
+const std::string& b = "54329.334";
 const auto& addResult1 = add(a, b, 0);
 const auto& addResult2 = add(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(addResult1, "120272.929");
@@ -50,7 +52,8 @@ _.assertIsEqual(addResult1, addResult2);
 SECTION_END()
 
 SECTION(Addition with negative numbers)
-const std::string &a = "-65943.595", &b = "54329.334";
+const std::string& a = "-65943.595";
+const std::string& b = "54329.334";
 const auto& addResult1 = add(a, b, 0);
 const auto& addResult2 = add(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(addResult1, "-11614.261");

--- a/tests/testComparison.cpp
+++ b/tests/testComparison.cpp
@@ -34,7 +34,8 @@ TEST_START()
 using namespace steppable::__internals::arithmetic;
 
 SECTION(Comparison at integer)
-const std::string &a = "6453.55", &b = "54329.334";
+const std::string &a = "6453.55";
+const std::string &b = "54329.334";
 const auto& compareResult1 = compare(a, b, 0);
 const auto& compareResult2 = compare(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(compareResult1, "0");
@@ -42,7 +43,8 @@ _.assertIsEqual(compareResult2, "1");
 SECTION_END()
 
 SECTION(Comparison by digit without decimal point)
-const std::string &a = "659", &b = "543";
+const std::string &a = "659";
+const std::string &b = "543";
 const auto& compareResult1 = compare(a, b, 0);
 const auto& compareResult2 = compare(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(compareResult1, "1");
@@ -50,7 +52,8 @@ _.assertIsEqual(compareResult2, "0");
 SECTION_END()
 
 SECTION(Comparison by digit with decimal point)
-const std::string &a = "659.2234", &b = "659.5242";
+const std::string &a = "659.2234";
+const std::string &b = "659.5242";
 const auto& compareResult1 = compare(a, b, 0);
 const auto& compareResult2 = compare(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(compareResult1, "0");

--- a/tests/testDivision.cpp
+++ b/tests/testDivision.cpp
@@ -35,9 +35,10 @@ using namespace steppable::__internals::arithmetic;
 
 SECTION(Integer division)
 // A gogol divided by 50
-const std::string
-    &a = "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-    &b = "50", &res = divide(a, b, 0, 0);
+const std::string& a =
+    "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const std::string& b = "50";
+const std::string& res = divide(a, b, 0, 0);
 
 _.assertIsEqual(res,
                 "200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
@@ -45,9 +46,10 @@ SECTION_END()
 
 SECTION(Integer divided by decimal)
 // A gogol divided by 79
-const std::string
-    &a = "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-    &b = "79", &res = divide(a, b, 0, 8);
+const std::string& a =
+    "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const std::string& b = "79";
+const std::string& res = divide(a, b, 0, 8);
 
 _.assertIsEqual(res,
                 "126582278481012658227848101265822784810126582278481012658"
@@ -55,24 +57,32 @@ _.assertIsEqual(res,
 SECTION_END()
 
 SECTION(Decimal divided by decimal)
-const std::string &a = "532.532132", &b = "53524.2353", &res = divide(a, b, 0, 8);
+const std::string& a = "532.532132";
+const std::string& b = "53524.2353";
+const std::string& res = divide(a, b, 0, 8);
 
 _.assertIsEqual(res, "0.00994936");
 SECTION_END()
 
 SECTION(Division with less decimal places than requested)
-const std::string &a = "1", &b = "2", &res = divide(a, b, 0, 8);
+const std::string& a = "1";
+const std::string& b = "2";
+const std::string& res = divide(a, b, 0, 8);
 
 _.assertIsEqual(res, "0.50000000");
 SECTION_END()
 
 SECTION(Division with negative numbers)
-const std::string &a = "-1", &b = "2", &res = divide(a, b, 0, 8);
+const std::string& a = "-1";
+const std::string& b = "2";
+const std::string& res = divide(a, b, 0, 8);
 _.assertIsEqual(res, "-0.50000000");
 SECTION_END()
 
 SECTION(Division with negative numbers)
-const std::string &a = "1", &b = "-2", &res = divide(a, b, 0, 8);
+const std::string& a = "1";
+const std::string& b = "-2";
+const std::string& res = divide(a, b, 0, 8);
 _.assertIsEqual(res, "-0.50000000");
 SECTION_END()
 

--- a/tests/testFactors.cpp
+++ b/tests/testFactors.cpp
@@ -49,10 +49,10 @@ _.assertIsEqual(getGreatestRootNum("5"), "4");
 SECTION_END()
 
 SECTION(Greatest Root Factor Test)
-_.assertIsEqual(getRootFactor("24", "2"), "4");
-_.assertIsEqual(getRootFactor("13", "2"), "1");
-_.assertIsEqual(getRootFactor("27", "2"), "9");
-_.assertIsEqual(getRootFactor("72", "2"), "36");
+_.assertIsEqual(getRootFactor("24", "2").getOutput(), "4");
+_.assertIsEqual(getRootFactor("13", "2").getOutput(), "1");
+_.assertIsEqual(getRootFactor("27", "2").getOutput(), "9");
+_.assertIsEqual(getRootFactor("72", "2").getOutput(), "36");
 SECTION_END()
 
 TEST_END()

--- a/tests/testFactors.cpp
+++ b/tests/testFactors.cpp
@@ -20,32 +20,36 @@
  * SOFTWARE.                                                                                      *
  **************************************************************************************************/
 
-#include "colors.hpp"
-#include "fn/basicArithm.hpp"
-#include "output.hpp"
+#include "colors.hpp" // IWYU pragma: keep
+#include "factors.hpp" // IWYU pragma: keep
+#include "output.hpp" // IWYU pragma: keep
 #include "testing.hpp"
-#include "util.hpp"
+#include "util.hpp" // IWYU pragma: keep
 
-#include <iomanip>
-#include <iostream>
+#include <iomanip> // IWYU pragma: keep
+#include <iostream> // IWYU pragma: keep
 
 TEST_START()
+using namespace steppable::__internals::numUtils;
 
-using namespace steppable::__internals::arithmetic;
-
-SECTION(Decimal Convert without letters)
-const std::string &a = "46432231133131";
-const std::string &b = "8";
-const auto& result = decimalConvert(a, b, 0);
-
-_.assertIsEqual(result, "2649229669977");
+SECTION(Prime Test)
+_.assertTrue(isPrime("2"));
+_.assertTrue(isPrime("3"));
+_.assertFalse(isPrime("16"));
+_.assertFalse(isPrime("100"));
+_.assertFalse(isPrime("1000"));
+_.assertFalse(isPrime("10000"));
 SECTION_END()
 
-SECTION(Decimal Convert)
-const std::string &a = "88a";
-const std::string &b = "16";
-const auto& result = decimalConvert(a, b, 0);
-
-_.assertIsEqual(result, "2186");
+SECTION(Greatest Square Number Test)
+_.assertIsEqual(getGreatestRootNum("2"), "1");
+_.assertIsEqual(getGreatestRootNum("3"), "1");
+_.assertIsEqual(getGreatestRootNum("4"), "4");
+_.assertIsEqual(getGreatestRootNum("5"), "4");
 SECTION_END()
+
+SECTION(Greatest Root Factor Test)
+_.assertIsEqual(getRootFactor("24", "2"), "4");
+SECTION_END()
+
 TEST_END()

--- a/tests/testMultiply.cpp
+++ b/tests/testMultiply.cpp
@@ -34,7 +34,8 @@ TEST_START()
 using namespace steppable::__internals::arithmetic;
 
 SECTION(Multiplication without carry)
-const std::string &a = "2", &b = "4";
+const std::string &a = "2";
+const std::string &b = "4";
 const auto& multiplyResult1 = multiply(a, b, 0);
 const auto& multiplyResult2 = multiply(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(multiplyResult1, "8");
@@ -42,7 +43,8 @@ _.assertIsEqual(multiplyResult1, multiplyResult2);
 SECTION_END()
 
 SECTION(Multiplication with one carry)
-const std::string &a = "56", &b = "45";
+const std::string &a = "56";
+const std::string &b = "45";
 const auto& multiplyResult1 = multiply(a, b, 0);
 const auto& multiplyResult2 = multiply(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(multiplyResult1, "2520");
@@ -50,7 +52,8 @@ _.assertIsEqual(multiplyResult1, multiplyResult2);
 SECTION_END()
 
 SECTION(Multiplication with two carries)
-const std::string &a = "12", &b = "9";
+const std::string &a = "12";
+const std::string &b = "9";
 const auto& multiplyResult1 = multiply(a, b, 0);
 const auto& multiplyResult2 = multiply(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(multiplyResult1, "108");
@@ -58,7 +61,8 @@ _.assertIsEqual(multiplyResult1, multiplyResult2);
 SECTION_END()
 
 SECTION(Multiplication with negative numbers)
-const std::string &a = "-12", &b = "9";
+const std::string &a = "-12";
+const std::string &b = "9";
 const auto& multiplyResult1 = multiply(a, b, 0);
 const auto& multiplyResult2 = multiply(b, a, 0); // Makes sure it works when a and b are reordered.
 _.assertIsEqual(multiplyResult1, "-108");

--- a/tests/testPower.cpp
+++ b/tests/testPower.cpp
@@ -35,32 +35,32 @@ TEST_START()
 using namespace steppable::__internals::arithmetic;
 
 SECTION(Power)
-const std::string_view &number = "47";
-const std::string_view &raiseTo = "10";
+const std::string number = "47";
+const std::string raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "52599132235830049");
 SECTION_END()
 
 SECTION(Power with Decimals)
-const std::string_view &number = "47.5";
-const std::string_view &raiseTo = "10";
+const std::string number = "47.5";
+const std::string raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "58470404222497940.0634765625");
 SECTION_END()
 
 SECTION(Power with Decimals)
-const std::string_view &number = "0.5";
-const std::string_view &raiseTo = "10";
+const std::string number = "0.5";
+const std::string raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "0.0009765625");
 SECTION_END()
 
 SECTION(Power with Decimal Exponents)
-const std::string_view &number = "4";
-const std::string_view &raiseTo = "0.5";
+const std::string number = "4";
+const std::string raiseTo = "0.5";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(numUtils::roundOff(result), "2");

--- a/tests/testPower.cpp
+++ b/tests/testPower.cpp
@@ -35,28 +35,32 @@ TEST_START()
 using namespace steppable::__internals::arithmetic;
 
 SECTION(Power)
-const std::string_view &number = "47", &raiseTo = "10";
+const std::string_view &number = "47";
+const std::string_view &raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "52599132235830049");
 SECTION_END()
 
 SECTION(Power with Decimals)
-const std::string_view &number = "47.5", &raiseTo = "10";
+const std::string_view &number = "47.5";
+const std::string_view &raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "58470404222497940.0634765625");
 SECTION_END()
 
 SECTION(Power with Decimals)
-const std::string_view &number = "0.5", &raiseTo = "10";
+const std::string_view &number = "0.5";
+const std::string_view &raiseTo = "10";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(result, "0.0009765625");
 SECTION_END()
 
 SECTION(Power with Decimal Exponents)
-const std::string_view &number = "4", &raiseTo = "0.5";
+const std::string_view &number = "4";
+const std::string_view &raiseTo = "0.5";
 const auto& result = power(number, raiseTo, 0);
 
 _.assertIsEqual(numUtils::roundOff(result), "2");

--- a/tests/testRoot.cpp
+++ b/tests/testRoot.cpp
@@ -39,4 +39,11 @@ SECTION(Root with a decimal index)
 using namespace steppable::__internals::arithmetic;
 _.assertIsEqual(root("4", "0.5", 0, 0), "16");
 SECTION_END()
+
+SECTION(Surds)
+using namespace steppable::__internals::arithmetic;
+auto surd = rootSurd("27", "2");
+_.assertIsEqual(surd.multiplier, "3");
+_.assertIsEqual(surd.radicand, "3");
+SECTION_END()
 TEST_END()

--- a/tests/testSubtract.cpp
+++ b/tests/testSubtract.cpp
@@ -34,7 +34,8 @@ TEST_START()
 using namespace steppable::__internals::arithmetic;
 
 SECTION(Subtraction with multiple digits of different length)
-const std::string &a = "54329.334", &b = "6345.55";
+const std::string &a = "54329.334";
+const std::string &b = "6345.55";
 const auto& subtractResult = subtract(a, b, 0);
 
 _.assertIsEqual(subtractResult, "47983.784");

--- a/tests/testUtil.cpp
+++ b/tests/testUtil.cpp
@@ -37,9 +37,12 @@ using namespace steppable::__internals::numUtils;
 using namespace steppable::__internals::stringUtils;
 
 SECTION(isZeroString)
-const std::string &string1 = "0", &string2 = "3", &string3 = "a";
-const bool isZeroString1 = isZeroString(string1), isZeroString2 = isZeroString(string2),
-           isZeroString3 = isZeroString(string3);
+const std::string& string1 = "0";
+const std::string& string2 = "3";
+const std::string& string3 = "a";
+const bool isZeroString1 = isZeroString(string1);
+const bool isZeroString2 = isZeroString(string2);
+const bool isZeroString3 = isZeroString(string3);
 
 _.assertTrue(isZeroString1);
 _.assertFalse(isZeroString2);
@@ -47,8 +50,12 @@ _.assertFalse(isZeroString3);
 SECTION_END()
 
 SECTION(isNumber)
-const std::string &string1 = "123", &string2 = "113241.43152", &string3 = "a13489b";
-const bool isNumber1 = isNumber(string1), isNumber2 = isNumber(string2), isNumber3 = isNumber(string3);
+const std::string& string1 = "123";
+const std::string& string2 = "113241.43152";
+const std::string& string3 = "a13489b";
+const bool isNumber1 = isNumber(string1);
+const bool isNumber2 = isNumber(string2);
+const bool isNumber3 = isNumber(string3);
 
 _.assertTrue(isNumber1);
 _.assertTrue(isNumber2);
@@ -56,18 +63,24 @@ _.assertFalse(isNumber3);
 SECTION_END()
 
 SECTION(split)
-const std::string &string1 = "1,2,3", &string2 = "1", &string3 = ",,,", &string4 = "";
-const auto &out1 = split(string1, ','), &out2 = split(string2, ','), &out3 = split(string3, ','),
-           &out4 = split(string4, ',');
+const std::string& string1 = "1,2,3";
+const std::string& string2 = "1";
+const std::string& string3 = ",,,";
+const std::string& string4 = "";
+const auto& out1 = split(string1, ',');
+const auto& out2 = split(string2, ',');
+const auto& out3 = split(string3, ',');
+const auto& out4 = split(string4, ',');
 
-_.assertIsEqual(out1.size(), 3);
-_.assertIsEqual(out2.size(), 1);
-_.assertIsEqual(out3.size(), 3);
-_.assertIsEqual(out4.size(), 0);
+_.assertIsEqual(static_cast<int>(out1.size()), 3);
+_.assertIsEqual(static_cast<int>(out2.size()), 1);
+_.assertIsEqual(static_cast<int>(out3.size()), 3);
+_.assertIsEqual(static_cast<int>(out4.size()), 0);
 SECTION_END()
 
 SECTION(splitNumber without padInteger or padDecimal)
-const std::string &number1 = "1.24", &number2 = "2";
+const std::string& number1 = "1.24";
+const std::string& number2 = "2";
 const auto& out = splitNumber(number1, number2, false, false).splitNumberArray;
 
 _.assertIsEqual(out[0], "1");
@@ -77,7 +90,8 @@ _.assertIsEqual(out[3], "");
 SECTION_END()
 
 SECTION(splitNumber with padInteger except padDecimal)
-const std::string &number1 = "11.24", &number2 = "2";
+const std::string& number1 = "11.24";
+const std::string& number2 = "2";
 const auto& out = splitNumber(number1, number2, true, false).splitNumberArray;
 
 _.assertIsEqual(out[0], "11");
@@ -87,7 +101,8 @@ _.assertIsEqual(out[3], "");
 SECTION_END()
 
 SECTION(splitNumber with padInteger and padDecimal)
-const std::string &number1 = "11.24", &number2 = "2.2";
+const std::string& number1 = "11.24";
+const std::string& number2 = "2.2";
 const auto& out = splitNumber(number1, number2, true, true).splitNumberArray;
 
 _.assertIsEqual(out[0], "11");
@@ -97,9 +112,12 @@ _.assertIsEqual(out[3], "20");
 SECTION_END()
 
 SECTION(lReplace)
-const std::string &string1 = "aaaaaab", &string2 = "bbb";
-const auto &out1 = lReplace(string1, 'a'), &out2 = lReplace(string2, 'a'), &out3 = lReplace(string1, 'a', 'c'),
-           &out4 = lReplace(string2, 'a', 'c');
+const std::string& string1 = "aaaaaab";
+const std::string& string2 = "bbb";
+const auto& out1 = lReplace(string1, 'a');
+const auto& out2 = lReplace(string2, 'a');
+const auto& out3 = lReplace(string1, 'a', 'c');
+const auto& out4 = lReplace(string2, 'a', 'c');
 
 _.assertIsEqual(out1, "b");
 _.assertIsEqual(out2, "bbb");
@@ -108,9 +126,12 @@ _.assertIsEqual(out4, "bbb");
 SECTION_END()
 
 SECTION(rReplace)
-const std::string &string1 = "baaaaaa", string2 = "bbb";
-const auto &out1 = rReplace(string1, 'a'), out2 = rReplace(string2, 'a'), &out3 = rReplace(string1, 'a', 'c'),
-           &out4 = rReplace(string2, 'a', 'c');
+const std::string& string1 = "baaaaaa";
+const std::string string2 = "bbb";
+const auto& out1 = rReplace(string1, 'a');
+const auto out2 = rReplace(string2, 'a');
+const auto& out3 = rReplace(string1, 'a', 'c');
+const auto& out4 = rReplace(string2, 'a', 'c');
 
 _.assertIsEqual(out1, "b");
 _.assertIsEqual(out2, "bbb");
@@ -119,9 +140,12 @@ _.assertIsEqual(out4, "bbb");
 SECTION_END()
 
 SECTION(bothEndsReplace)
-const std::string &string1 = "baaaabb", &string2 = "aaa";
-const auto &out1 = bothEndsReplace(string1, 'b'), &out2 = bothEndsReplace(string2, 'b'),
-           &out3 = bothEndsReplace(string1, 'b', 'c'), &out4 = bothEndsReplace(string2, 'b', 'c');
+const std::string& string1 = "baaaabb";
+const std::string& string2 = "aaa";
+const auto& out1 = bothEndsReplace(string1, 'b');
+const auto& out2 = bothEndsReplace(string2, 'b');
+const auto& out3 = bothEndsReplace(string1, 'b', 'c');
+const auto& out4 = bothEndsReplace(string2, 'b', 'c');
 
 _.assertIsEqual(out1, "aaaa");
 _.assertIsEqual(out2, "aaa");
@@ -133,7 +157,7 @@ SECTION(removeLeadingZeros)
 const std::vector<int>& vector = { 0, 0, 142, 0, 142, 0, 0 };
 const auto& out = replaceLeadingZeros(vector);
 
-_.assertIsEqual(out.size(), 7);
+_.assertIsEqual(static_cast<int>(out.size()), 7);
 _.assertIsEqual(out[0], out[1]);
 _.assertIsEqual(out[0], -2);
 SECTION_END()
@@ -153,6 +177,10 @@ _.assertIsEqual(roundOff(number1, 1), "1.6");
 const std::string& number2 = "1.9";
 _.assertIsEqual(roundOff(number2, 0), "2");
 _.assertIsEqual(roundOff(number2, 1), "2.0");
+
+const std::string& number3 = "1.9";
+_.assertIsEqual(roundDown(number2), "1");
+_.assertIsEqual(roundUp(number2), "2");
 SECTION_END()
 
 TEST_END()

--- a/tools/run_clang_tidy.py
+++ b/tools/run_clang_tidy.py
@@ -1,0 +1,584 @@
+#####################################################################################################
+#  Copyright (c) 2023-2024 NWSOFT                                                                   #
+#                                                                                                   #
+#  Permission is hereby granted, free of charge, to any person obtaining a copy                     #
+#  of this software and associated documentation files (the "Software"), to deal                    #
+#  in the Software without restriction, including without limitation the rights                     #
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                        #
+#  copies of the Software, and to permit persons to whom the Software is                            #
+#  furnished to do so, subject to the following conditions:                                         #
+#                                                                                                   #
+#  The above copyright notice and this permission notice shall be included in all                   #
+#  copies or substantial portions of the Software.                                                  #
+#                                                                                                   #
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                       #
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                         #
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                      #
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                           #
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                    #
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE                    #
+#  SOFTWARE.                                                                                        #
+#####################################################################################################
+
+# LICENSE NOTE:
+# Modified from LLVM run-clang-tidy.py, originally under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+import argparse
+import glob
+import json
+import multiprocessing
+import os
+import queue
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def strtobool(val):
+    """Convert a string representation of truth to a bool following LLVM's CLI argument parsing."""
+
+    val = val.lower()
+    if val in ["", "true", "1"]:
+        return True
+    elif val in ["false", "0"]:
+        return False
+
+    # Return ArgumentTypeError so that argparse does not substitute its own error message
+    raise argparse.ArgumentTypeError(
+        "'{}' is invalid value for boolean argument! Try 0 or 1.".format(val)
+    )
+
+
+def find_compilation_database(path):
+    """Adjusts the directory until a compilation database is found."""
+    result = os.path.realpath("./")
+    while not os.path.isfile(os.path.join(result, path)):
+        parent = os.path.dirname(result)
+        if result == parent:
+            print("Error: could not find compilation database.")
+            sys.exit(1)
+        result = parent
+    return result
+
+
+def make_absolute(f, directory):
+    if os.path.isabs(f):
+        return f
+    return os.path.normpath(os.path.join(directory, f))
+
+
+def get_tidy_invocation(
+    f,
+    clang_tidy_binary,
+    checks,
+    tmpdir,
+    build_path,
+    header_filter,
+    allow_enabling_alpha_checkers,
+    extra_arg,
+    extra_arg_before,
+    quiet,
+    config_file_path,
+    config,
+    line_filter,
+    use_color,
+    plugins,
+    warnings_as_errors,
+):
+    """Gets a command line for clang-tidy."""
+    start = [clang_tidy_binary]
+    if allow_enabling_alpha_checkers:
+        start.append("-allow-enabling-analyzer-alpha-checkers")
+    if header_filter is not None:
+        start.append("-header-filter=" + header_filter)
+    if line_filter is not None:
+        start.append("-line-filter=" + line_filter)
+    if use_color is not None:
+        if use_color:
+            start.append("--use-color")
+        else:
+            start.append("--use-color=false")
+    if checks:
+        start.append("-checks=" + checks)
+    if tmpdir is not None:
+        start.append("-export-fixes")
+        # Get a temporary file. We immediately close the handle so clang-tidy can
+        # overwrite it.
+        (handle, name) = tempfile.mkstemp(suffix=".yaml", dir=tmpdir)
+        os.close(handle)
+        start.append(name)
+    for arg in extra_arg:
+        start.append("-extra-arg=%s" % arg)
+    for arg in extra_arg_before:
+        start.append("-extra-arg-before=%s" % arg)
+    start.append("-p=" + build_path)
+    if quiet:
+        start.append("-quiet")
+    if config_file_path:
+        start.append("--config-file=" + config_file_path)
+    elif config:
+        start.append("-config=" + config)
+    for plugin in plugins:
+        start.append("-load=" + plugin)
+    if warnings_as_errors:
+        start.append("--warnings-as-errors=" + warnings_as_errors)
+    start.append(f)
+    return start
+
+
+def merge_replacement_files(tmpdir, mergefile):
+    """Merge all replacement files in a directory into a single file"""
+    # The fixes suggested by clang-tidy >= 4.0.0 are given under
+    # the top level key 'Diagnostics' in the output yaml files
+    mergekey = "Diagnostics"
+    merged = []
+    for replacefile in glob.iglob(os.path.join(tmpdir, "*.yaml")):
+        content = yaml.safe_load(open(replacefile, "r"))
+        if not content:
+            continue  # Skip empty files.
+        merged.extend(content.get(mergekey, []))
+
+    if merged:
+        # MainSourceFile: The key is required by the definition inside
+        # include/clang/Tooling/ReplacementsYaml.h, but the value
+        # is actually never used inside clang-apply-replacements,
+        # so we set it to '' here.
+        output = {"MainSourceFile": "", mergekey: merged}
+        with open(mergefile, "w") as out:
+            yaml.safe_dump(output, out)
+    else:
+        # Empty the file:
+        open(mergefile, "w").close()
+
+
+def find_binary(arg, name, build_path):
+    """Get the path for a binary or exit"""
+    if arg:
+        if shutil.which(arg):
+            return arg
+        else:
+            raise SystemExit(
+                "error: passed binary '{}' was not found or is not executable".format(
+                    arg
+                )
+            )
+
+    built_path = os.path.join(build_path, "bin", name)
+    binary = shutil.which(name) or shutil.which(built_path)
+    if binary:
+        return binary
+    else:
+        raise SystemExit(
+            "error: failed to find {} in $PATH or at {}".format(name, built_path)
+        )
+
+
+def apply_fixes(args, clang_apply_replacements_binary, tmpdir):
+    """Calls clang-apply-fixes on a given directory."""
+    invocation = [clang_apply_replacements_binary]
+    invocation.append("-ignore-insert-conflict")
+    if args.format:
+        invocation.append("-format")
+    if args.style:
+        invocation.append("-style=" + args.style)
+    invocation.append(tmpdir)
+    subprocess.call(invocation)
+
+
+def run_tidy(args, clang_tidy_binary, tmpdir, build_path, queue, lock, failed_files):
+    """Takes filenames out of queue and runs clang-tidy on them."""
+    while True:
+        name = queue.get()
+        invocation = get_tidy_invocation(
+            name,
+            clang_tidy_binary,
+            args.checks,
+            tmpdir,
+            build_path,
+            args.header_filter,
+            args.allow_enabling_alpha_checkers,
+            args.extra_arg,
+            args.extra_arg_before,
+            args.quiet,
+            args.config_file,
+            args.config,
+            args.line_filter,
+            args.use_color,
+            args.plugins,
+            args.warnings_as_errors,
+        )
+
+        proc = subprocess.Popen(
+            invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        output, err = proc.communicate()
+        if proc.returncode != 0:
+            if proc.returncode < 0:
+                msg = "%s: terminated by signal %d\n" % (name, -proc.returncode)
+                err += msg.encode("utf-8")
+            failed_files.append(name)
+        with lock:
+            sys.stdout.write(" ".join(invocation) + "\n" + output.decode("utf-8"))
+            if len(err) > 0:
+                sys.stdout.flush()
+                sys.stderr.write(err.decode("utf-8"))
+        queue.task_done()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Runs clang-tidy over all files in a compilation database. Requires clang-tidy and clang-apply-replacements"
+            " in $PATH or in your build directory."
+        )
+    )
+    parser.add_argument(
+        "-allow-enabling-alpha-checkers",
+        action="store_true",
+        help="allow alpha checkers from clang-analyzer.",
+    )
+    parser.add_argument(
+        "-clang-tidy-binary", metavar="PATH", help="path to clang-tidy binary"
+    )
+    parser.add_argument(
+        "-clang-apply-replacements-binary",
+        metavar="PATH",
+        help="path to clang-apply-replacements binary",
+    )
+    parser.add_argument(
+        "-checks",
+        default=None,
+        help="checks filter, when not specified, use clang-tidy default",
+    )
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument(
+        "-config",
+        default=None,
+        help=(
+            "Specifies a configuration in YAML/JSON format: "
+            "  -config=\"{Checks: '*', "
+            '                       CheckOptions: {x: y}}" '
+            "When the value is empty, clang-tidy will "
+            "attempt to find a file named .clang-tidy for "
+            "each source file in its parent directories."
+        ),
+    )
+    config_group.add_argument(
+        "-config-file",
+        default=None,
+        help=(
+            "Specify the path of .clang-tidy or custom config "
+            "file: e.g. -config-file=/some/path/myTidyConfigFile. "
+            "This option internally works exactly the same way as "
+            "-config option after reading specified config file. "
+            "Use either -config-file or -config, not both."
+        ),
+    )
+    parser.add_argument(
+        "-header-filter",
+        default=None,
+        help=(
+            "regular expression matching the names of the "
+            "headers to output diagnostics from. Diagnostics from "
+            "the main file of each translation unit are always "
+            "displayed."
+        ),
+    )
+    parser.add_argument(
+        "-source-filter",
+        default=None,
+        help=(
+            "Regular expression matching the names of the source files that will be excluded from compilation database "
+            "to output diagnostics from."
+        ),
+    )
+    parser.add_argument(
+        "-line-filter",
+        default=None,
+        help="List of files with line ranges to filter the warnings.",
+    )
+    if yaml:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="file_or_directory",
+            dest="export_fixes",
+            help=(
+                "A directory or a yaml file to store suggested fixes in, "
+                "which can be applied with clang-apply-replacements. If the "
+                "parameter is a directory, the fixes of each compilation unit are "
+                "stored in individual yaml files in the directory."
+            ),
+        )
+    else:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="directory",
+            dest="export_fixes",
+            help=(
+                "A directory to store suggested fixes in, which can be applied "
+                "with clang-apply-replacements. The fixes of each compilation unit are "
+                "stored in individual yaml files in the directory."
+            ),
+        )
+    parser.add_argument(
+        "-j",
+        type=int,
+        default=0,
+        help="number of tidy instances to be run in parallel.",
+    )
+    parser.add_argument(
+        "files", nargs="*", default=[".*"], help="files to be processed (regex on path)"
+    )
+    parser.add_argument("-fix", action="store_true", help="apply fix-its")
+    parser.add_argument(
+        "-format", action="store_true", help="Reformat code after applying fixes"
+    )
+    parser.add_argument(
+        "-style",
+        default="file",
+        help="The style of reformat code after applying fixes",
+    )
+    parser.add_argument(
+        "-use-color",
+        type=strtobool,
+        nargs="?",
+        const=True,
+        help=(
+            "Use colors in diagnostics, overriding clang-tidy's"
+            " default behavior. This option overrides the 'UseColor"
+            "' option in .clang-tidy file, if any."
+        ),
+    )
+    parser.add_argument(
+        "-p", dest="build_path", help="Path used to read a compile command database."
+    )
+    parser.add_argument(
+        "-extra-arg",
+        dest="extra_arg",
+        action="append",
+        default=[],
+        help="Additional argument to append to the compiler command line.",
+    )
+    parser.add_argument(
+        "-extra-arg-before",
+        dest="extra_arg_before",
+        action="append",
+        default=[],
+        help="Additional argument to prepend to the compiler command line.",
+    )
+    parser.add_argument(
+        "-quiet", action="store_true", help="Run clang-tidy in quiet mode"
+    )
+    parser.add_argument(
+        "-load",
+        dest="plugins",
+        action="append",
+        default=[],
+        help="Load the specified plugin in clang-tidy.",
+    )
+    parser.add_argument(
+        "-warnings-as-errors",
+        default=None,
+        help="Upgrades warnings to errors. Same format as '-checks'",
+    )
+    args = parser.parse_args()
+
+    db_path = "compile_commands.json"
+
+    if args.build_path is not None:
+        build_path = args.build_path
+    else:
+        # Find our database
+        build_path = find_compilation_database(db_path)
+
+    clang_tidy_binary = find_binary(args.clang_tidy_binary, "clang-tidy", build_path)
+
+    if args.fix:
+        clang_apply_replacements_binary = find_binary(
+            args.clang_apply_replacements_binary, "clang-apply-replacements", build_path
+        )
+
+    combine_fixes = False
+    export_fixes_dir = None
+    delete_fixes_dir = False
+    if args.export_fixes is not None:
+        # if a directory is given, create it if it does not exist
+        if args.export_fixes.endswith(os.path.sep) and not os.path.isdir(
+            args.export_fixes
+        ):
+            os.makedirs(args.export_fixes)
+
+        if not os.path.isdir(args.export_fixes):
+            if not yaml:
+                raise RuntimeError(
+                    "Cannot combine fixes in one yaml file. Either install PyYAML or specify an output directory."
+                )
+
+            combine_fixes = True
+
+        if os.path.isdir(args.export_fixes):
+            export_fixes_dir = args.export_fixes
+
+    if export_fixes_dir is None and (args.fix or combine_fixes):
+        export_fixes_dir = tempfile.mkdtemp()
+        delete_fixes_dir = True
+
+    try:
+        invocation = get_tidy_invocation(
+            "",
+            clang_tidy_binary,
+            args.checks,
+            None,
+            build_path,
+            args.header_filter,
+            args.allow_enabling_alpha_checkers,
+            args.extra_arg,
+            args.extra_arg_before,
+            args.quiet,
+            args.config_file,
+            args.config,
+            args.line_filter,
+            args.use_color,
+            args.plugins,
+            args.warnings_as_errors,
+        )
+        invocation.append("-list-checks")
+        invocation.append("-")
+        if args.quiet:
+            # Even with -quiet we still want to check if we can call clang-tidy.
+            with open(os.devnull, "w") as dev_null:
+                subprocess.check_call(invocation, stdout=dev_null)
+        else:
+            subprocess.check_call(invocation)
+    except:
+        print("Unable to run clang-tidy.", file=sys.stderr)
+        sys.exit(1)
+
+    # Load the database and extract all files.
+    database = json.load(open(os.path.join(build_path, db_path)))
+    files = set(
+        [make_absolute(entry["file"], entry["directory"]) for entry in database]
+    )
+
+    # Filter out source files from compilation database.
+    if args.source_filter:
+        try:
+            source_filter_re = re.compile(args.source_filter)
+        except:
+            print(
+                "Error: unable to compile regex from arg -source-filter:",
+                file=sys.stderr,
+            )
+            traceback.print_exc()
+            sys.exit(1)
+        files = {f for f in files if not source_filter_re.match(f)}
+
+    max_task = args.j
+    if max_task == 0:
+        max_task = multiprocessing.cpu_count()
+
+    # Build up a big regexy filter from all command line arguments.
+    file_name_re = re.compile("|".join(args.files))
+
+    return_code = 0
+    try:
+        # Spin up a bunch of tidy-launching threads.
+        task_queue = queue.Queue(max_task)
+        # List of files with a non-zero return code.
+        failed_files = []
+        lock = threading.Lock()
+        for _ in range(max_task):
+            t = threading.Thread(
+                target=run_tidy,
+                args=(
+                    args,
+                    clang_tidy_binary,
+                    export_fixes_dir,
+                    build_path,
+                    task_queue,
+                    lock,
+                    failed_files,
+                ),
+            )
+            t.daemon = True
+            t.start()
+
+        # Fill the queue with files.
+        for name in files:
+            if file_name_re.search(name):
+                task_queue.put(name)
+
+        # Wait for all threads to be done.
+        task_queue.join()
+        if len(failed_files):
+            return_code = 1
+
+    except KeyboardInterrupt:
+        # This is a sad hack. Unfortunately subprocess goes
+        # bonkers with ctrl-c and we start forking merrily.
+        print("\nCtrl-C detected, goodbye.")
+        if delete_fixes_dir:
+            shutil.rmtree(export_fixes_dir)
+        os.kill(0, 9)
+
+    if combine_fixes:
+        print("Writing fixes to " + args.export_fixes + " ...")
+        try:
+            merge_replacement_files(export_fixes_dir, args.export_fixes)
+        except:
+            print("Error exporting fixes.\n", file=sys.stderr)
+            traceback.print_exc()
+            return_code = 1
+
+    if args.fix:
+        print("Applying fixes ...")
+        try:
+            apply_fixes(args, clang_apply_replacements_binary, export_fixes_dir)
+        except:
+            print("Error applying fixes.\n", file=sys.stderr)
+            traceback.print_exc()
+            return_code = 1
+
+    if delete_fixes_dir:
+        shutil.rmtree(export_fixes_dir)
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When calculating roots in form

$$ \sqrt[n]{a^n \cdot b} $$

Where $a$ and $b$ are integers, we can simplify it into:

$$ a \sqrt[n]{b} $$

<details>
<summary>Changelog:</summary>

- **Improve `random_test` output.**
- **WIP: Fix according to clang-tidy checks.**
- **Added the `rootSurd` function.**
  - Add rootSurd function to convert a root to a surd.
  - Fix compile problems (not initializing `va_list`).
  - Add factors.hpp and factors.cpp functions.
- **Fixed build problems and improve `rootSurd` function.**
  - Fixed the align attribute not available on Windows.
  - Add tests for the rootSurd function.
- **Fix build problems on Linux.**
- **Using surds to simplify roots.**
- **Fixed clang-tidy issues.**
- **Using `Result` to save calculation time of `root`.**
  - Added ResultBase, Result and ResultBool objects.
  - getRootFactors uses ResultBool to return the root of the factor along with the factor.
  - Fixed a bug in multiply that moves more decimal places than needed if the input b is a decimal.
</details>
